### PR TITLE
feat: implement three-level configuration precedence

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,0 +1,113 @@
+# Configuration Precedence in chat.md
+
+This document explains the three-level configuration system for `reasoningEffort`, `maxTokens`, and `maxThinkingTokens` parameters.
+
+## Configuration Levels (in order of precedence)
+
+### 1. File-specific Configuration (Highest Priority)
+Configuration defined at the beginning of a `.chat.md` file before any `# %%` blocks:
+
+```
+selectedConfig="my-provider"
+reasoningEffort="high"
+maxTokens=4000
+maxThinkingTokens=20000
+
+# %% system
+Your system prompt here
+
+# %% user  
+Your message here
+```
+
+### 2. Provider-specific Configuration (Middle Priority)
+Configuration defined in VS Code settings for a specific API provider:
+
+```json
+{
+  "chatmd.apiConfigs": {
+    "anthropic-high": {
+      "type": "anthropic",
+      "apiKey": "your-api-key",
+      "model_name": "claude-3-5-haiku-latest",
+      "reasoningEffort": "medium",
+      "maxTokens": 6000,
+      "maxThinkingTokens": 18000
+    },
+    "openai-reasoning": {
+      "type": "openai", 
+      "apiKey": "your-api-key",
+      "model_name": "o1-preview",
+      "base_url": "https://api.openai.com/v1/chat/completions",
+      "reasoningEffort": "low",
+      "maxTokens": 8000,
+      "maxThinkingTokens": 16000
+    }
+  }
+}
+```
+
+### 3. Global Configuration (Lowest Priority)
+Global VS Code settings that apply when no file or provider-specific configuration is found:
+
+```json
+{
+  "chatmd.reasoningEffort": "medium",
+  "chatmd.maxTokens": 8000,
+  "chatmd.maxThinkingTokens": 16000
+}
+```
+
+## Parameter Descriptions
+
+### reasoningEffort
+Controls the reasoning effort level for LLM responses:
+- `"minimal"`: Very minimal thinking
+- `"low"`: Low reasoning effort  
+- `"medium"`: Medium reasoning effort (default)
+- `"high"`: High reasoning effort
+
+**Usage by Provider:**
+- **OpenAI**: Sets the `reasoning_effort` parameter directly
+- **Anthropic**: Used to calculate thinking token budget if `maxThinkingTokens` is not explicitly set
+
+### maxTokens  
+Maximum number of tokens to generate in responses:
+- **Anthropic**: Used as the `max_tokens` parameter
+- **OpenAI**: Used as the `max_completion_tokens` parameter (includes both thinking and response tokens)
+
+### maxThinkingTokens
+Maximum number of thinking tokens for reasoning models:
+- **Anthropic**: Sets `thinking.max_tokens` parameter if configured
+- **OpenAI**: Currently used for internal token budget calculations
+
+## Examples
+
+### Example 1: File overrides provider config
+```
+selectedConfig="anthropic-default"
+maxTokens=2000
+
+# %% system
+Be very concise.
+
+# %% user
+Explain quantum computing.
+```
+This will use `maxTokens=2000` from the file, even if "anthropic-default" provider has a different `maxTokens` value.
+
+### Example 2: Provider config overrides global
+If your global settings have `maxTokens=8000` but your provider config has `maxTokens=4000`, and no file-specific config exists, it will use `4000`.
+
+### Example 3: Reasoning effort calculation
+If you set `reasoningEffort="high"` but don't set `maxThinkingTokens`, Anthropic will automatically calculate thinking tokens as 80% of `maxTokens`.
+
+## Allowed File-specific Keys
+Only these keys are allowed in `.chat.md` file preambles:
+- `selectedConfig` - Name of the provider configuration to use
+- `reasoningEffort` - Reasoning effort level  
+- `maxTokens` - Maximum response tokens
+- `maxThinkingTokens` - Maximum thinking tokens
+
+Forbidden keys (must be in global settings only):
+- `type`, `apiKey`, `base_url`, `model_name`, `apiConfigs`

--- a/README.md
+++ b/README.md
@@ -111,12 +111,33 @@ Optionally you can start a markdown preview side by side to get live markdown pr
 
 ## Configuration
 
-Access these settings through VS Code's settings UI or settings.json:
+chat.md supports a three-level configuration system with the following precedence (highest to lowest):
 
-- `chatmd.apiConfigs`: Named API configurations (provider, API key, model, base URL)
+1. **File-specific configuration** - Set at the top of individual `.chat.md` files
+2. **Provider-specific configuration** - Set in VS Code settings for each API provider  
+3. **Global configuration** - Default VS Code settings
+
+### File-specific Configuration
+Configure parameters at the beginning of any `.chat.md` file:
+```
+selectedConfig="my-provider"
+reasoningEffort="high"
+maxTokens=4000
+maxThinkingTokens=20000
+
+# %% system
+Your system prompt here
+```
+
+### VS Code Settings
+Access these through VS Code's settings UI or settings.json:
+
+- `chatmd.apiConfigs`: Named API configurations (provider, API key, model, base URL, plus optional reasoning/token settings)
 - `chatmd.selectedConfig`: Active API configuration
 - `chatmd.mcpServers`: Configure MCP tool servers
-- `chatmd.reasoningEffort`: Control reasoning depth (minimal, low, medium, high)
+- `chatmd.reasoningEffort`: Global reasoning depth (minimal, low, medium, high)
+- `chatmd.maxTokens`: Global maximum response tokens
+- `chatmd.maxThinkingTokens`: Global maximum thinking tokens
 
 ### Tool Execution
 
@@ -215,7 +236,10 @@ vscode json settings
       "type": "anthropic",
       "apiKey": "sk-ant-",
       "base_url": "",
-      "model_name": "claude-3-7-sonnet-latest"
+      "model_name": "claude-3-7-sonnet-latest",
+      "reasoningEffort": "high",
+      "maxTokens": 6000,
+      "maxThinkingTokens": 18000
     },
     "openrouter-qasar": {
       "type": "openai",
@@ -268,9 +292,11 @@ vscode json settings
   "chatmd.reasoningEffort": "medium"
 ```
 
-Note: `maxTokens` (default: 8000) controls the maximum number of tokens for model responses.
-For OpenAI reasoning models (GPT-5, o3, o1 series), `maxTokens` is used as the total `max_completion_tokens` budget (includes both thinking and response tokens).
-For Anthropic models, `maxThinkingTokens` controls the thinking token budget separately, or can be calculated automatically from `reasoningEffort`.
+**Configuration Notes:**
+- `maxTokens` (default: 8000) controls the maximum number of tokens for model responses
+- For OpenAI reasoning models (o1, o3 series), `maxTokens` is used as the total `max_completion_tokens` budget (includes both thinking and response tokens)  
+- For Anthropic models, `maxThinkingTokens` controls the thinking token budget separately, or can be calculated automatically from `reasoningEffort`
+- Provider-specific configurations override global settings, and file-specific configurations override both (see [CONFIGURATION.md](CONFIGURATION.md) for detailed precedence rules)
 ## License
 
 MIT License - see the LICENSE file for details.

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
         "chatmd.apiConfigs": {
           "type": "object",
           "description": "Dictionary of named API configurations",
-          "additionalProperties": {
+            "additionalProperties": {
             "type": "object",
             "properties": {
               "type": {
@@ -133,6 +133,24 @@
               "model_name": {
                 "type": "string",
                 "description": "Model name to use with the selected provider"
+              },
+              "reasoningEffort": {
+                "type": "string",
+                "enum": [
+                  "minimal",
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "description": "Reasoning effort level for this provider configuration (overrides global setting)"
+              },
+              "maxTokens": {
+                "type": "number",
+                "description": "Maximum number of tokens to generate for this provider configuration (overrides global setting)"
+              },
+              "maxThinkingTokens": {
+                "type": "number",
+                "description": "Maximum number of thinking tokens for this provider configuration (overrides global setting)"
               }
             },
             "required": [

--- a/src/anthropicClient.ts
+++ b/src/anthropicClient.ts
@@ -25,6 +25,8 @@ export class AnthropicClient {
     document?: vscode.TextDocument,
     systemPrompt?: string,
     modelNameOverride?: string,
+    configName?: string,
+    fileConfig?: Record<string, any>,
   ): AsyncGenerator<string[], void, unknown> {
     log(`Starting API request with ${messages.length} messages`);
 
@@ -48,11 +50,11 @@ export class AnthropicClient {
       const systemPromptToUse =
         systemPrompt || generateToolCallingSystemPrompt();
 
-      // Get configuration values
+      // Get configuration values with proper precedence (file config > provider config > global config)
       const { getMaxTokens, getMaxThinkingTokens, getReasoningEffort, calculateThinkingTokensFromEffort } = require("./config");
-      const maxTokens = getMaxTokens();
-      const configuredThinkingTokens = getMaxThinkingTokens();
-      const reasoningEffort = getReasoningEffort();
+      const maxTokens = getMaxTokens(configName, fileConfig);
+      const configuredThinkingTokens = getMaxThinkingTokens(configName, fileConfig);
+      const reasoningEffort = getReasoningEffort(configName, fileConfig);
       
       const requestBody: any = {
         model: modelName,

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,9 @@ export interface ApiConfig {
   apiKey: string;
   model_name?: string;
   base_url?: string;
+  reasoningEffort?: "minimal" | "low" | "medium" | "high";
+  maxTokens?: number;
+  maxThinkingTokens?: number;
 }
 
 /**
@@ -354,21 +357,60 @@ export function getBaseUrl(): string | undefined {
 /**
  * Gets the maximum number of thinking tokens to use
  * Used for Anthropic thinking parameter and OpenAI max_completion_tokens calculation
+ * @param configName Optional specific config name to check first
+ * @param fileConfig Optional file-specific configuration
  * @returns The number of thinking tokens to use (default: 16000)
  */
-export function getMaxThinkingTokens(): number {
-  // Get from configuration if available, otherwise use default
+export function getMaxThinkingTokens(configName?: string, fileConfig?: Record<string, any>): number {
+  // 1. First check file-specific config (highest priority)
+  if (fileConfig?.maxThinkingTokens !== undefined) {
+    log(`Using maxThinkingTokens from file config: ${fileConfig.maxThinkingTokens}`);
+    return fileConfig.maxThinkingTokens;
+  }
+
+  // 2. Then check provider-specific config
+  if (configName) {
+    const providerConfig = getConfigByName(configName);
+    if (providerConfig?.maxThinkingTokens !== undefined) {
+      log(`Using maxThinkingTokens from provider config '${configName}': ${providerConfig.maxThinkingTokens}`);
+      return providerConfig.maxThinkingTokens;
+    }
+  }
+
+  // 3. Finally check global config
   const config = vscode.workspace.getConfiguration("chatmd");
-  return config.get("maxThinkingTokens") || 16000; // Default to 16k tokens
+  const globalValue = config.get<number>("maxThinkingTokens") || 16000;
+  log(`Using maxThinkingTokens from global config: ${globalValue}`);
+  return globalValue;
 }
 
 /**
  * Gets the reasoning effort setting
+ * @param configName Optional specific config name to check first
+ * @param fileConfig Optional file-specific configuration
  * @returns The reasoning effort level (minimal, low, medium, high) or undefined if not set
  */
-export function getReasoningEffort(): "minimal" | "low" | "medium" | "high" | undefined {
+export function getReasoningEffort(configName?: string, fileConfig?: Record<string, any>): "minimal" | "low" | "medium" | "high" | undefined {
+  // 1. First check file-specific config (highest priority)
+  if (fileConfig?.reasoningEffort !== undefined) {
+    log(`Using reasoningEffort from file config: ${fileConfig.reasoningEffort}`);
+    return fileConfig.reasoningEffort;
+  }
+
+  // 2. Then check provider-specific config
+  if (configName) {
+    const providerConfig = getConfigByName(configName);
+    if (providerConfig?.reasoningEffort !== undefined) {
+      log(`Using reasoningEffort from provider config '${configName}': ${providerConfig.reasoningEffort}`);
+      return providerConfig.reasoningEffort;
+    }
+  }
+
+  // 3. Finally check global config
   const config = vscode.workspace.getConfiguration("chatmd");
-  return config.get("reasoningEffort");
+  const globalValue = config.get<"minimal" | "low" | "medium" | "high">("reasoningEffort");
+  log(`Using reasoningEffort from global config: ${globalValue}`);
+  return globalValue;
 }
 
 /**
@@ -403,12 +445,31 @@ export function calculateThinkingTokensFromEffort(
 /**
  * Gets the maximum number of tokens to generate
  * This is used as max_tokens for Anthropic models and as part of max_completion_tokens for OpenAI models
+ * @param configName Optional specific config name to check first
+ * @param fileConfig Optional file-specific configuration
  * @returns The number of max tokens to use (default: 8000)
  */
-export function getMaxTokens(): number {
-  // Get from configuration if available, otherwise use default
+export function getMaxTokens(configName?: string, fileConfig?: Record<string, any>): number {
+  // 1. First check file-specific config (highest priority)
+  if (fileConfig?.maxTokens !== undefined) {
+    log(`Using maxTokens from file config: ${fileConfig.maxTokens}`);
+    return fileConfig.maxTokens;
+  }
+
+  // 2. Then check provider-specific config
+  if (configName) {
+    const providerConfig = getConfigByName(configName);
+    if (providerConfig?.maxTokens !== undefined) {
+      log(`Using maxTokens from provider config '${configName}': ${providerConfig.maxTokens}`);
+      return providerConfig.maxTokens;
+    }
+  }
+
+  // 3. Finally check global config
   const config = vscode.workspace.getConfiguration("chatmd");
-  return config.get("maxTokens") || 8000; // Default to 8k tokens
+  const globalValue = config.get<number>("maxTokens") || 8000;
+  log(`Using maxTokens from global config: ${globalValue}`);
+  return globalValue;
 }
 
 /**

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -873,7 +873,7 @@ ${JSON.stringify(parsedToolCall.params, null, 2)}
     
     // Start streaming, which will continue from where the last response left off
     streamingService
-      .streamResponse(updatedMessages, streamer, finalSystemPrompt)
+      .streamResponse(updatedMessages, streamer, finalSystemPrompt, 0, 0, (parseResult as any).fileConfig)
       .catch((err: any) => {
         log(`Resume streaming error for index ${messageIndex}: ${err}`);
       })
@@ -1028,9 +1028,9 @@ ${JSON.stringify(parsedToolCall.params, null, 2)}
         requestStatusBarUpdate(this.document.uri.fsPath, "new streamer created");
       } catch {}
 
-      // **Start streaming in background, passing the FINAL system prompt**
+      // **Start streaming in background, passing the FINAL system prompt and file config**
       streamingService
-        .streamResponse(messages, streamer, finalSystemPrompt) // Pass the combined prompt
+        .streamResponse(messages, streamer, finalSystemPrompt, 0, 0, (parseResult as any).fileConfig) // Pass the combined prompt and file config
         .catch((err) => {
           log(`Streaming error for index ${messageIndex}: ${err}`);
         })

--- a/src/openaiClient.ts
+++ b/src/openaiClient.ts
@@ -56,6 +56,8 @@ export class OpenAIClient {
     document?: vscode.TextDocument,
     systemPrompt?: string,
     modelNameOverride?: string,
+    configName?: string,
+    fileConfig?: Record<string, any>,
   ): AsyncGenerator<string[], void, unknown> {
     log(`Starting OpenAI API request with ${messages.length} messages`);
 
@@ -86,10 +88,10 @@ export class OpenAIClient {
       // Use fallback if needed
       modelName = modelName || "gpt-3.5-turbo";
 
-      // Get the max tokens value from configuration
+      // Get configuration values with proper precedence (file config > provider config > global config)
       const { getMaxTokens, getReasoningEffort } = require("./config");
-      const maxTokens = getMaxTokens();
-      const reasoningEffort = getReasoningEffort();
+      const maxTokens = getMaxTokens(configName, fileConfig);
+      const reasoningEffort = getReasoningEffort(configName, fileConfig);
       
       // Initial request body
       const requestBody: any = {

--- a/src/streamer.ts
+++ b/src/streamer.ts
@@ -158,7 +158,8 @@ export class StreamingService {
     streamer: StreamerState,
     systemPrompt: string, // Added systemPrompt parameter
     currentRetryAttempt: number = 0, // Add parameter to track retry attempts across recursive calls
-    maxTokenRetryAttempt: number = 0 // Add parameter to track max token retries
+    maxTokenRetryAttempt: number = 0, // Add parameter to track max token retries
+    fileConfig?: Record<string, any> // Add optional file configuration parameter
   ): Promise<void> {
     // Flag to track if we need to restart due to max tokens
     let maxTokensReached = false;
@@ -202,6 +203,8 @@ export class StreamingService {
               this.document,
               systemPrompt,
               modelNameOverride,
+              this.configNameOverride,
+              fileConfig,
             );
           } else if (this.provider === "openai" && this.openaiClient) {
             stream = await this.openaiClient.streamCompletion(
@@ -209,6 +212,8 @@ export class StreamingService {
               this.document,
               systemPrompt,
               modelNameOverride,
+              this.configNameOverride,
+              fileConfig,
             );
           } else {
             throw new Error(
@@ -676,7 +681,8 @@ export class StreamingService {
                   streamer,
                   systemPrompt,
                   retryAttempt, // Pass the current retry count to maintain it across calls
-                  tokenRetryAttempt // Pass the token retry count
+                  tokenRetryAttempt, // Pass the token retry count
+                  fileConfig // Pass the file configuration
                 );
                 return; // If successful, exit this function
               } catch (retryError) {

--- a/test-config-precedence.chat.md
+++ b/test-config-precedence.chat.md
@@ -1,0 +1,15 @@
+selectedConfig="anthropic-test"
+reasoningEffort="high"
+maxTokens=4000
+maxThinkingTokens=20000
+
+# %% system
+
+You are a helpful assistant. Please provide concise answers.
+
+# %% user
+
+What are the key features of TypeScript?
+
+# %% assistant
+


### PR DESCRIPTION
## Summary

Implements a three-level configuration system for `reasoningEffort`, `maxTokens`, and `maxThinkingTokens` parameters with the following precedence (highest to lowest):

1. **File-specific configuration** - Set at the top of individual `.chat.md` files
2. **Provider-specific configuration** - Set in VS Code settings for each API provider  
3. **Global configuration** - Default VS Code settings

## Changes Made

### Core Features
- ✅ Enhanced `ApiConfig` interface with optional reasoning/token parameters
- ✅ Updated configuration functions to support precedence logic
- ✅ Modified parser to accept new file-specific configuration keys
- ✅ Updated both AnthropicClient and OpenAIClient to use new precedence system
- ✅ Added advanced configuration options to VS Code extension UI

### Documentation
- ✅ Updated README.md with configuration overview
- ✅ Added comprehensive CONFIGURATION.md with examples and usage patterns
- ✅ Updated VS Code settings schema in package.json

### Testing
- ✅ All TypeScript compilation passes without errors
- ✅ Build process completes successfully
- ✅ Backward compatibility maintained - existing configurations continue to work

## Usage Examples

### File-specific Configuration
```
selectedConfig="my-provider"
reasoningEffort="high"
maxTokens=4000
maxThinkingTokens=20000

# %% system
Your system prompt here
```

### Provider-specific Configuration
```json
{
  "chatmd.apiConfigs": {
    "anthropic-high": {
      "type": "anthropic",
      "apiKey": "your-api-key",
      "reasoningEffort": "medium",
      "maxTokens": 6000,
      "maxThinkingTokens": 18000
    }
  }
}
```

## Implementation Notes

- File-specific configurations override provider-specific configurations
- Provider-specific configurations override global settings
- All changes are backward compatible
- Logging added to track which configuration source is being used
- Proper TypeScript typing throughout

Fixes configuration precedence requirements by implementing the requested three-level system.
