### PR TITLE
Improve streaming, reasoning, history, and repository integration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,15 @@ jobs:
       - name: Build extension
         run: npm run vscode:prepublish
 
+      - name: Build VSIX package
+        run: npm run build:vsix
+
       - name: Publish to Visual Studio Marketplace
-        run: vsce publish -p $VSCE_PAT
+        run: vsce publish -p "$VSCE_PAT"
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Publish to Open VSX Registry
+        run: npx --yes ovsx publish ./*.vsix -p "$OVSX_PAT"
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "filechat",
   "displayName": "chat.md",
   "description": "Interact with LLMs directly in markdown files. Features include tool integration, auto-execution control, and customizable behavior.",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "publisher": "AmanRusia",
   "license": "MIT",
   "icon": "./images/icon.png",

--- a/package.json
+++ b/package.json
@@ -153,6 +153,15 @@
                 ],
                 "description": "Reasoning effort level for this provider configuration (overrides global setting)"
               },
+              "openaiApi": {
+                "type": "string",
+                "enum": [
+                  "auto",
+                  "chat",
+                  "responses"
+                ],
+                "description": "Which OpenAI API to use for this configuration. 'auto' uses the Responses API for OpenAI hosted gpt and o-series models (required to keep encrypted reasoning across turns) and chat completions everywhere else."
+              },
               "maxTokens": {
                 "type": "number",
                 "description": "Maximum number of tokens to generate for this provider configuration (overrides global setting)"
@@ -262,6 +271,17 @@
             "high"
           ],
           "description": "Reasoning effort level for LLM responses. For OpenAI: controls reasoning_effort parameter. For Anthropic: used to calculate thinking token budget if maxThinkingTokens is not set.",
+          "scope": "application"
+        },
+        "chatmd.openaiApi": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "chat",
+            "responses"
+          ],
+          "default": "auto",
+          "description": "Which OpenAI API to use. 'auto' uses the Responses API for OpenAI hosted gpt and o-series models (required to keep encrypted reasoning across turns) and chat completions everywhere else.",
           "scope": "application"
         }
       }

--- a/package.json
+++ b/package.json
@@ -273,6 +273,12 @@
           "description": "Reasoning effort level for LLM responses. For OpenAI: controls reasoning_effort parameter. For Anthropic: used to calculate thinking token budget if maxThinkingTokens is not set.",
           "scope": "application"
         },
+        "chatmd.assetsPath": {
+          "type": "string",
+          "description": "Directory for chat.md assets such as tool results and reasoning payloads. Relative paths are resolved from each chat file.",
+          "default": "cmdassets",
+          "scope": "application"
+        },
         "chatmd.openaiApi": {
           "type": "string",
           "enum": [

--- a/src/anthropicClient.ts
+++ b/src/anthropicClient.ts
@@ -1,11 +1,23 @@
 import * as https from "https";
 import * as http from "http";
 import * as path from "path";
-import { MessageParam, Content } from "./types";
+import { MessageParam, Content, ThinkingPayload } from "./types";
 import { resolveFilePath, readFileAsBuffer } from "./utils/fileUtils";
 import * as vscode from "vscode";
 import { log } from "./extension";
 import { generateToolCallingSystemPrompt } from "./config";
+import {
+  encodeThinkingPayloadToken,
+  encodeThinkingToken,
+} from "./utils/thinkingBlocks";
+import { cleanMessagesForApi } from "./utils/messageCleanup";
+import {
+  isAdaptiveThinkingModel,
+  needsInterleavedThinkingBeta,
+  omitsThinkingByDefault,
+  requiresAlwaysOnThinking,
+  toAdaptiveEffort,
+} from "./utils/modelCapabilities";
 
 /**
  * Client for communicating with the Anthropic API
@@ -31,7 +43,6 @@ export class AnthropicClient {
     log(`Starting API request with ${messages.length} messages`);
 
     try {
-      const formattedMessages = this.formatMessages(messages, document);
       // Resolve model name (allow per-file override)
       let modelName = modelNameOverride;
       if (!modelName) {
@@ -55,38 +66,82 @@ export class AnthropicClient {
       const maxTokens = getMaxTokens(configName, fileConfig);
       const configuredThinkingTokens = getMaxThinkingTokens(configName, fileConfig);
       const reasoningEffort = getReasoningEffort(configName, fileConfig);
-      
+
+      // Thinking is on unless it was explicitly turned off
+      const thinkingEnabled = reasoningEffort !== "none";
+      const adaptive = isAdaptiveThinkingModel(modelName);
+
       const requestBody: any = {
         model: modelName,
-        messages: formattedMessages,
         system: systemPromptToUse,
         stream: true,
         max_tokens: maxTokens,
       };
 
-      // Determine thinking token budget for Anthropic
-      let thinkingTokens;
-      
-      // If maxThinkingTokens is explicitly configured and not the default, use that
-      if (configuredThinkingTokens && configuredThinkingTokens !== 16000) {
-        thinkingTokens = configuredThinkingTokens;
-        log(`Using configured thinking tokens: ${thinkingTokens}`);
-      } 
-      // If reasoning effort is configured, calculate thinking tokens from it
-      else if (reasoningEffort) {
-        thinkingTokens = calculateThinkingTokensFromEffort(maxTokens, reasoningEffort);
-        log(`Using thinking tokens calculated from reasoning effort "${reasoningEffort}": ${thinkingTokens}`);
+      if (adaptive) {
+        // Claude 4.6+ replaced budget_tokens with adaptive thinking + effort
+        if (thinkingEnabled) {
+          requestBody.thinking = { type: "adaptive" };
+          if (omitsThinkingByDefault(modelName)) {
+            // These models omit thinking from the response unless asked for it
+            requestBody.thinking.display = "summarized";
+          }
+          if (reasoningEffort) {
+            requestBody.output_config = {
+              effort: toAdaptiveEffort(reasoningEffort),
+            };
+          }
+          log(
+            `Using adaptive thinking: ${JSON.stringify(requestBody.thinking)}${requestBody.output_config ? ` with ${JSON.stringify(requestBody.output_config)}` : ""}`,
+          );
+        } else if (!requiresAlwaysOnThinking(modelName)) {
+          requestBody.thinking = { type: "disabled" };
+          log("Thinking disabled for adaptive thinking model");
+        } else {
+          log(
+            "Model requires always-on adaptive thinking, omitting thinking param",
+          );
+        }
+      } else if (thinkingEnabled) {
+        // Older models: extended thinking with an explicit token budget
+        let thinkingTokens: number | undefined;
+        if (configuredThinkingTokens && configuredThinkingTokens !== 16000) {
+          thinkingTokens = configuredThinkingTokens;
+          log(`Using configured thinking tokens: ${thinkingTokens}`);
+        } else if (reasoningEffort) {
+          thinkingTokens = calculateThinkingTokensFromEffort(maxTokens, reasoningEffort);
+          log(
+            `Using thinking tokens calculated from reasoning effort "${reasoningEffort}": ${thinkingTokens}`,
+          );
+        } else {
+          log("No thinking token configuration, letting Anthropic decide");
+        }
+
+        if (thinkingTokens) {
+          const budgetTokens = Math.max(1024, thinkingTokens);
+          requestBody.thinking = {
+            type: "enabled",
+            budget_tokens: budgetTokens,
+          };
+          // Anthropic requires max_tokens to be greater than the thinking budget
+          if (requestBody.max_tokens <= budgetTokens) {
+            requestBody.max_tokens = budgetTokens + maxTokens;
+            log(
+              `Raised max_tokens to ${requestBody.max_tokens} to exceed thinking budget ${budgetTokens}`,
+            );
+          }
+          log(`Setting Anthropic thinking budget_tokens: ${budgetTokens}`);
+        }
       }
-      // Otherwise, don't set thinking tokens (let Anthropic handle it automatically)
-      else {
-        log("No thinking token configuration, letting Anthropic handle automatically");
-      }
-      
-      // Add thinking tokens parameter if we calculated one
-      if (thinkingTokens) {
-        requestBody.thinking = { max_tokens: thinkingTokens };
-        log(`Setting Anthropic thinking.max_tokens: ${thinkingTokens}`);
-      }
+
+      // Thinking blocks may only be replayed when thinking is actually enabled
+      const thinkingActive = Boolean(requestBody.thinking) && thinkingEnabled;
+      const cleanedMessages = cleanMessagesForApi(messages, {
+        modelName,
+        thinkingEnabled: thinkingActive,
+        apiStyle: "anthropic",
+      });
+      requestBody.messages = this.formatMessages(cleanedMessages, document);
 
       log(
         `Using system prompt for tool calling (${systemPromptToUse.length} chars)`,
@@ -94,13 +149,20 @@ export class AnthropicClient {
 
       log(`Using Anthropic model: ${requestBody.model}`);
 
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        "Anthropic-Version": this.apiVersion,
+        "x-api-key": this.apiKey,
+      };
+
+      if (thinkingActive && needsInterleavedThinkingBeta(modelName)) {
+        headers["anthropic-beta"] = "interleaved-thinking-2025-05-14";
+        log("Requesting interleaved thinking beta");
+      }
+
       const requestOptions = {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "Anthropic-Version": this.apiVersion,
-          "x-api-key": this.apiKey,
-        },
+        headers,
       };
 
       log("Creating HTTPS request");
@@ -169,7 +231,7 @@ export class AnthropicClient {
       }
 
       log("Processing streaming response");
-      yield* this.createStreamGenerator(response);
+      yield* this.createStreamGenerator(response, modelName);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       log(`Error in streamCompletion: ${message}`);
@@ -185,9 +247,12 @@ export class AnthropicClient {
    */
   private async *createStreamGenerator(
     response: http.IncomingMessage,
+    modelName: string,
   ): AsyncGenerator<string[], void, unknown> {
     let buffer = "";
     let eventCount = 0;
+    // Accumulated thinking text of the block currently being streamed
+    let thinkingText = "";
 
     try {
       for await (const chunk of response) {
@@ -242,10 +307,51 @@ export class AnthropicClient {
                 log(`Received token: "${data.delta.text}"`);
                 // Ensure we're sending tokens for text_delta events
                 yield [data.delta.text];
+              } else if (
+                data.type === "content_block_delta" &&
+                data.delta &&
+                data.delta.type === "thinking_delta" &&
+                data.delta.thinking
+              ) {
+                thinkingText += data.delta.thinking;
+                yield [encodeThinkingToken(data.delta.thinking)];
+              } else if (
+                data.type === "content_block_delta" &&
+                data.delta &&
+                data.delta.type === "signature_delta" &&
+                data.delta.signature
+              ) {
+                // The signature closes the thinking block. Keep the exact thinking
+                // text with it so it can be replayed byte for byte later on.
+                log("Received thinking signature");
+                const payload: ThinkingPayload & { model: string } = {
+                  model: modelName,
+                  kind: "anthropic_signature",
+                  signature: data.delta.signature,
+                  text: thinkingText,
+                };
+                thinkingText = "";
+                yield [encodeThinkingPayloadToken(payload)];
               } else if (data.type === "content_block_start") {
                 log(
                   `Content block start: ${JSON.stringify(data.content_block)}`,
                 );
+                const block = data.content_block;
+                if (block && block.type === "redacted_thinking" && block.data) {
+                  log("Received redacted thinking block");
+                  const payload: ThinkingPayload & { model: string } = {
+                    model: modelName,
+                    kind: "anthropic_redacted",
+                    data: block.data,
+                  };
+                  yield [
+                    encodeThinkingToken("[redacted thinking]"),
+                    encodeThinkingPayloadToken(payload),
+                  ];
+                } else if (block && block.type === "thinking" && block.thinking) {
+                  thinkingText += block.thinking;
+                  yield [encodeThinkingToken(block.thinking)];
+                }
               } else if (data.type === "message_delta") {
                 log(`Message delta received: ${JSON.stringify(data.delta)}`);
               } else if (data.type === "message_start") {
@@ -308,9 +414,27 @@ export class AnthropicClient {
     contentItems: readonly Content[],
     document?: vscode.TextDocument,
   ): any[] {
-    return contentItems.map((content) => {
+    const blocks: any[] = [];
+
+    for (const content of contentItems) {
       if (content.type === "text") {
-        return { type: "text", text: content.value };
+        blocks.push({ type: "text", text: content.value });
+      } else if (content.type === "thinking") {
+        const payload = content.payload;
+        if (payload?.kind === "anthropic_redacted" && payload.data) {
+          blocks.push({ type: "redacted_thinking", data: payload.data });
+        } else if (payload?.kind === "anthropic_signature" && payload.signature) {
+          // Prefer the exact text captured with the signature; the document copy is
+          // trimmed for display and would not verify.
+          blocks.push({
+            type: "thinking",
+            thinking: payload.text ?? "",
+            signature: payload.signature,
+          });
+        } else {
+          // Raw thinking without a signature cannot be replayed to Anthropic
+          log("Skipping thinking block without an Anthropic signature");
+        }
       } else if (content.type === "image") {
         try {
           // Resolve image path relative to document if needed
@@ -321,34 +445,40 @@ export class AnthropicClient {
           // Read image file and convert to base64
           const imageData = readFileAsBuffer(imagePath);
           if (!imageData) {
-            return {
+            blocks.push({
               type: "text",
               text: `[Failed to load image: ${content.path}]`,
-            };
+            });
+            continue;
           }
 
           const base64Data = imageData.toString("base64");
           const mimeType = this.getMimeType(imagePath);
 
-          return {
+          blocks.push({
             type: "image",
             source: {
               type: "base64",
               media_type: mimeType,
               data: base64Data,
             },
-          };
+          });
         } catch (error) {
           console.error(`Error processing image ${content.path}:`, error);
-          // Return empty text if image can't be processed
-          return {
+          // Push text if image can't be processed
+          blocks.push({
             type: "text",
             text: `[Failed to load image: ${content.path}]`,
-          };
+          });
         }
       }
-      return { type: "text", text: "" };
-    });
+    }
+
+    if (blocks.length === 0) {
+      blocks.push({ type: "text", text: "[continuing]" });
+    }
+
+    return blocks;
   }
 
   /**

--- a/src/anthropicClient.ts
+++ b/src/anthropicClient.ts
@@ -23,6 +23,7 @@ import {
  * Client for communicating with the Anthropic API
  */
 export class AnthropicClient {
+  public lastUsage: Record<string, unknown> | undefined;
   private readonly apiUrl = "https://api.anthropic.com/v1/messages";
   private readonly apiVersion = "2023-06-01"; // This version should work for streaming
 
@@ -40,6 +41,7 @@ export class AnthropicClient {
     configName?: string,
     fileConfig?: Record<string, any>,
   ): AsyncGenerator<string[], void, unknown> {
+    this.lastUsage = undefined;
     log(`Starting API request with ${messages.length} messages`);
 
     try {
@@ -352,8 +354,24 @@ export class AnthropicClient {
                   yield [encodeThinkingToken(block.thinking)];
                 }
               } else if (data.type === "message_delta") {
+                if (data.usage) {
+                  this.lastUsage = {
+                    ...(this.lastUsage || {}),
+                    outputTokens: data.usage.output_tokens,
+                    cacheReadTokens: data.usage.cache_read_input_tokens,
+                    cacheWriteTokens: data.usage.cache_creation_input_tokens,
+                  };
+                }
                 log(`Message delta received: ${JSON.stringify(data.delta)}`);
               } else if (data.type === "message_start") {
+                if (data.message?.usage) {
+                  this.lastUsage = {
+                    inputTokens: data.message.usage.input_tokens,
+                    outputTokens: data.message.usage.output_tokens,
+                    cacheReadTokens: data.message.usage.cache_read_input_tokens,
+                    cacheWriteTokens: data.message.usage.cache_creation_input_tokens,
+                  };
+                }
                 log(`Message start received: ${JSON.stringify(data.message)}`);
               } else if (data.type === "message_stop") {
                 log("Received message_stop event");

--- a/src/anthropicClient.ts
+++ b/src/anthropicClient.ts
@@ -328,7 +328,6 @@ export class AnthropicClient {
                   model: modelName,
                   kind: "anthropic_signature",
                   signature: data.delta.signature,
-                  text: thinkingText,
                 };
                 thinkingText = "";
                 yield [encodeThinkingPayloadToken(payload)];
@@ -424,11 +423,10 @@ export class AnthropicClient {
         if (payload?.kind === "anthropic_redacted" && payload.data) {
           blocks.push({ type: "redacted_thinking", data: payload.data });
         } else if (payload?.kind === "anthropic_signature" && payload.signature) {
-          // Prefer the exact text captured with the signature; the document copy is
-          // trimmed for display and would not verify.
+          // When opaque content exists, text is irrelevant to the API
           blocks.push({
             type: "thinking",
-            thinking: payload.text ?? "",
+            thinking: "",
             signature: payload.signature,
           });
         } else {

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,11 @@ export interface ApiConfig {
   reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high";
   maxTokens?: number;
   maxThinkingTokens?: number;
+  /**
+   * Which OpenAI API flavour to use. "auto" picks the Responses API for OpenAI
+   * hosted gpt and o-series models, and chat completions everywhere else.
+   */
+  openaiApi?: "auto" | "chat" | "responses";
 }
 
 /**
@@ -527,6 +532,73 @@ export function getMaxTokens(configName?: string, fileConfig?: Record<string, an
   const globalValue = config.get<number>("maxTokens") || 8000;
   log(`Using maxTokens from global config: ${globalValue}`);
   return globalValue;
+}
+
+/**
+ * Resolves the model name using the same precedence as the API clients:
+ * per-file/named config first, then the global setting.
+ */
+export function resolveModelName(configName?: string): string | undefined {
+  if (configName) {
+    const fromConfig = getModelNameForConfig(configName);
+    if (fromConfig) {
+      return fromConfig;
+    }
+  }
+  return getModelName();
+}
+
+/**
+ * Gets the configured OpenAI API flavour ("auto" when unset)
+ */
+export function getOpenaiApiSetting(
+  configName?: string,
+  fileConfig?: Record<string, any>,
+): "auto" | "chat" | "responses" {
+  if (fileConfig?.openaiApi) {
+    log(`Using openaiApi from file config: ${fileConfig.openaiApi}`);
+    return fileConfig.openaiApi;
+  }
+
+  if (configName) {
+    const providerConfig = getConfigByName(configName);
+    if (providerConfig?.openaiApi) {
+      log(
+        `Using openaiApi from provider config '${configName}': ${providerConfig.openaiApi}`,
+      );
+      return providerConfig.openaiApi;
+    }
+  }
+
+  const config = vscode.workspace.getConfiguration("chatmd");
+  return config.get<"auto" | "chat" | "responses">("openaiApi") || "auto";
+}
+
+/**
+ * Decides whether an OpenAI request goes to the Responses API or chat completions.
+ * "auto" resolves to the Responses API only for OpenAI hosted gpt and o-series
+ * models, since no other host implements it.
+ */
+export function resolveOpenaiApiStyle(
+  modelName: string | undefined,
+  baseUrl: string | undefined,
+  configName?: string,
+  fileConfig?: Record<string, any>,
+): "chat" | "responses" {
+  const setting = getOpenaiApiSetting(configName, fileConfig);
+  if (setting === "chat" || setting === "responses") {
+    return setting;
+  }
+
+  const {
+    isResponsesApiModel,
+    isOpenAiBaseUrl,
+  } = require("./utils/modelCapabilities");
+
+  if (modelName && isResponsesApiModel(modelName) && isOpenAiBaseUrl(baseUrl)) {
+    return "responses";
+  }
+  return "chat";
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,7 +43,6 @@ export function generateToolCallingSystemPrompt(
    Input Schema:
    \`\`\`json
 ${JSON.stringify(tool.inputSchema, null, 2)}
-   \`\`\`
 `;
     toolIndex++;
   }
@@ -60,7 +59,6 @@ ${JSON.stringify(tool.inputSchema, null, 2)}
    Input Schema:
    \`\`\`json
 ${JSON.stringify(tool.inputSchema, null, 2)}
-   \`\`\`
 `;
       toolIndex++;
     }
@@ -79,20 +77,18 @@ Chatmd can ask follow-up questions in more conversational contexts, but avoids a
 
 Chatmd can use tools to perform actions when needed to complete the user's requests. Use the following XML-like format to call a tool inside a code fence block:
 
-\`\`\`tool_call
-<tool_call>
-<tool_name>toolName</tool_name>
-<param name="paramName">paramValue</param>
-</tool_call>
-\`\`\`
+<cmd:tool_call>
+<cmd:tool_name>toolName</cmd:tool_name>
+<cmd:param name="paramName">paramValue</cmd:param>
+</cmd:tool_call>
 
-Note: you should always give both \`\`\`tool_call and <tool_call>.
+Tool calls must use the exact cmd format and must not be wrapped in triple-backtick fences.
 
 IMPORTANT FORMATTING REQUIREMENTS:
 1. Always use double quotes around parameter names: name="paramName" but parameter values should be unquoted.
 2. Parameter values can be inline (no newlines required)
 3. Parameter names must exactly match those in the tool's schema.
-4. Always place the tool call within code fence blocks.
+4. Place the tool call directly in the response without code fences.
 
 Available tools:${toolsDescription}
 
@@ -107,48 +103,42 @@ Tool usage guidelines:
 - You don't need to quote characters like "<", ">", "&", etc. in parameter values.
 - You should use CDATA tag in the parameter value if it contains conflicting XML tags only, not for special characters.
 - Make sure to use correct parameter names with quotes (name="paramName")
-- In <param> value for scalar parameters (string, number, boolean), write values directly without quotes
+- In <cmd:param> value for scalar parameters (string, number, boolean), write values directly without quotes
 - For object/array type parameters, use properly encoded JSON format
 - Use \`system.fetch_mcp_resource\` when you need to read the contents of one of the advertised MCP resources. Pass the exact \`serverId\` and resource \`uri\` shown above.
 
-Correct: <param name="xml_content"><hello>{"greeting": "hello"}</hello></param>
-Incorrect: <param name="xml_content">&lt;hello&gt;{\"greeting\": \"hello\"}&lt;/hello&gt;</param>
-Correct: <param name="weather_object">{"temperature_3days": [20, 21, 19]}</param>
+Correct: <cmd:param name="xml_content"><hello>{"greeting": "hello"}</hello></cmd:param>
+Incorrect: <cmd:param name="xml_content">&lt;hello&gt;{\"greeting\": \"hello\"}&lt;/hello&gt;</cmd:param>
+Correct: <cmd:param name="weather_object">{"temperature_3days": [20, 21, 19]}</cmd:param>
 
 Examples of valid tool calls:
 
 Example 1 - a tool with a single scalar parameter:
 
-\`\`\`tool_call
-<tool_call>
-<tool_name>read_file</tool_name>
-<param name="path">/Users/me/project/main.py</param>
-</tool_call>
-\`\`\`
+<cmd:tool_call>
+<cmd:tool_name>read_file</cmd:tool_name>
+<cmd:param name="path">/Users/me/project/main.py</cmd:param>
+</cmd:tool_call>
 
 Example 2 - a tool with multiple parameters, including a multi-line value:
 
-\`\`\`tool_call
-<tool_call>
-<tool_name>write_file</tool_name>
-<param name="path">/tmp/hello.py</param>
-<param name="content">def greet(name):
+<cmd:tool_call>
+<cmd:tool_name>write_file</cmd:tool_name>
+<cmd:param name="path">/tmp/hello.py</cmd:param>
+<cmd:param name="content">def greet(name):
     print(f"Hello, {name}!")
 
 greet("world")
-</param>
-</tool_call>
-\`\`\`
+</cmd:param>
+</cmd:tool_call>
 
 Example 3 - a tool with a JSON object parameter:
 
-\`\`\`tool_call
-<tool_call>
-<tool_name>search_files</tool_name>
-<param name="query">TODO</param>
-<param name="options">{"case_sensitive": false, "max_results": 10}</param>
-</tool_call>
-\`\`\`
+<cmd:tool_call>
+<cmd:tool_name>search_files</cmd:tool_name>
+<cmd:param name="query">TODO</cmd:param>
+<cmd:param name="options">{"case_sensitive": false, "max_results": 10}</cmd:param>
+</cmd:tool_call>
 
 Chatmd provides the shortest answer it can to the person's message, while respecting any stated length and comprehensiveness preferences given by the person. Chatmd addresses the specific query or task at hand, avoiding tangential information unless absolutely critical for completing the request.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -95,6 +95,8 @@ ${resourcesDescription}
 
 After calling a tool, wait for the result.
 
+When several independent tools are needed, emit them as multiple tool calls back to back in the same response, one code fence block per tool call and nothing else between them. They are all executed and their results are returned before your next turn, so prefer this over one tool call per turn whenever the calls don't depend on each other's results.
+
 Tool usage guidelines:
 - Use the exact format shown above - it's a simplified XML-like format, not strict XML, you don't need to quote strings.
 - You don't need to quote characters like "<", ">", "&", etc. in parameter values.

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,6 +43,7 @@ export function generateToolCallingSystemPrompt(
    Input Schema:
    \`\`\`json
 ${JSON.stringify(tool.inputSchema, null, 2)}
+   \`\`\`
 `;
     toolIndex++;
   }
@@ -59,6 +60,7 @@ ${JSON.stringify(tool.inputSchema, null, 2)}
    Input Schema:
    \`\`\`json
 ${JSON.stringify(tool.inputSchema, null, 2)}
+   \`\`\`
 `;
       toolIndex++;
     }
@@ -75,7 +77,7 @@ Chatmd after doing a coding task asks the person if they would like it to explai
 Chatmd can ask follow-up questions in more conversational contexts, but avoids asking more than one question per response and keeps the one question short. Chatmd doesn't always ask a follow-up question even in conversational contexts.
 
 
-Chatmd can use tools to perform actions when needed to complete the user's requests. Use the following XML-like format to call a tool inside a code fence block:
+Chatmd can use tools to perform actions when needed to complete the user's requests. Use the following XML-like format to call a tool:
 
 <cmd:tool_call>
 <cmd:tool_name>toolName</cmd:tool_name>
@@ -89,6 +91,7 @@ IMPORTANT FORMATTING REQUIREMENTS:
 2. Parameter values can be inline (no newlines required)
 3. Parameter names must exactly match those in the tool's schema.
 4. Place the tool call directly in the response without code fences.
+5. The closing </cmd:tool_call> tag must start on its own line. A tool call written entirely on one line is not recognised.
 
 Available tools:${toolsDescription}
 
@@ -96,7 +99,7 @@ ${resourcesDescription}
 
 After calling a tool, wait for the result.
 
-When several independent tools are needed, emit them as multiple tool calls back to back in the same response, one code fence block per tool call and nothing else between them. They are all executed and their results are returned before your next turn, so prefer this over one tool call per turn whenever the calls don't depend on each other's results.
+When several independent tools are needed, emit them as multiple tool calls back to back in the same response, one complete <cmd:tool_call> block after another with nothing else between them. They are all executed and their results are returned before your next turn, so prefer this over one tool call per turn whenever the calls don't depend on each other's results.
 
 Tool usage guidelines:
 - Use the exact format shown above - it's a simplified XML-like format, not strict XML, you don't need to quote strings.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,7 +68,7 @@ function findGitRoot(startPath: string): string | undefined {
   }
 }
 
-function ensureChatMdGitignore(workspaceRoot: string): void {
+export function ensureChatMdGitignore(workspaceRoot: string): void {
   const gitRoot = findGitRoot(workspaceRoot);
   if (!gitRoot) {
     return;
@@ -444,11 +444,6 @@ export function activate(contextParam: vscode.ExtensionContext) {
 
   // Call the function that updates the status bar display
   updateStreamingStatusBar(); // Ensure this runs after setting the name
-
-  // Keep generated chat.md files out of repositories by default.
-  for (const workspaceFolder of vscode.workspace.workspaceFolders || []) {
-    ensureChatMdGitignore(workspaceFolder.uri.fsPath);
-  }
 
   // Register for .chat.md files
   const selector: vscode.DocumentSelector = { pattern: "**/*.chat.md" };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -350,20 +350,10 @@ function getDocumentListenerForDocument(document: vscode.TextDocument): Document
  * @returns True if a tool call is found, false otherwise
  */
 function checkForToolCallInText(text: string): boolean {
-  // Check for various tool call formats
-  const properlyFencedToolCallRegex =
-    /```(?:[a-zA-Z0-9_\-]*)?(?:\s*\n|\s+)(?:\s*)<tool_call>[\s\S]*?<\/tool_call>(?:\s*)\n\s*```/s;
-  const partiallyFencedToolCallRegex =
-    /```(?:[a-zA-Z0-9_\-]*)?(?:\s*\n|\s+)(?:\s*)<tool_call>[\s\S]*?<\/tool_call>(?!\s*\n\s*```)/s;
-  const nonFencedToolCallRegex = /<tool_call>[\s\S]*?<\/tool_call>/s;
-
-  return (
-    properlyFencedToolCallRegex.test(text) ||
-    partiallyFencedToolCallRegex.test(text) ||
-    nonFencedToolCallRegex.test(text)
-  );
+  const open = "<cmd:tool_call>";
+  const end = "</cmd:tool_call>";
+  return text.includes(open) && text.includes(end);
 }
-
 // Declare context at module level to make it available in initializeMcpClients
 let context: vscode.ExtensionContext;
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1003,26 +1003,7 @@ export function activate(contextParam: vscode.ExtensionContext) {
       }
     }),
     vscode.commands.registerCommand("filechat.newContextChat", async () => {
-      const activeEditor = vscode.window.activeTextEditor;
-      let streamerCancelled = false;
-
-      // Check if active editor is a chat file and if streaming is active
-      if (activeEditor && activeEditor.document.fileName.endsWith(".chat.md")) {
-        const streamer = getActiveStreamerForDocument(activeEditor.document);
-        if (streamer && streamer.isActive && streamer.cancel) {
-          log(
-            "newContextChat shortcut used while streaming: Cancelling stream.",
-          );
-          streamer.cancel();
-          vscode.window.showInformationMessage("chat.md streaming cancelled");
-          onActiveFileChanged(); // Update status bar after cancelling
-          streamerCancelled = true;
-        }
-      }
-
-      // If streaming was not cancelled, proceed with creating a new chat
-      if (!streamerCancelled) {
-        log("newContextChat shortcut used: Creating new context chat.");
+      log("newContextChat: Creating new context chat.");
         try {
           // Get current context (workspace, file, selection)
           const context = getCurrentContext();
@@ -1055,8 +1036,7 @@ export function activate(contextParam: vscode.ExtensionContext) {
             `Failed to create context chat: ${error}`,
           );
         }
-      } // This brace closes the if (!streamerCancelled) block
-    }), // This closes the registerCommand call
+    }),
 
     vscode.commands.registerCommand("filechat.newChat", async () => {
       // Create a new chat file

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,6 +51,61 @@ export function log(message: string): void {
   // Logging happens without showing the output channel automatically
 }
 
+function findGitRoot(startPath: string): string | undefined {
+  let currentPath = path.resolve(startPath);
+
+  while (true) {
+    const gitPath = path.join(currentPath, ".git");
+    if (fs.existsSync(gitPath)) {
+      return currentPath;
+    }
+
+    const parentPath = path.dirname(currentPath);
+    if (parentPath === currentPath) {
+      return undefined;
+    }
+    currentPath = parentPath;
+  }
+}
+
+function ensureChatMdGitignore(workspaceRoot: string): void {
+  const gitRoot = findGitRoot(workspaceRoot);
+  if (!gitRoot) {
+    return;
+  }
+
+  const gitignorePath = path.join(gitRoot, ".gitignore");
+  const entries = [".cmd_history/", "cmdassets/"];
+
+  try {
+    const existing = fs.existsSync(gitignorePath)
+      ? fs.readFileSync(gitignorePath, "utf8")
+      : "";
+    const lines = existing.split(/\r?\n/);
+    const missingEntries = entries.filter(
+      (entry) => !lines.some((line) => line.trim() === entry),
+    );
+
+    if (missingEntries.length === 0) {
+      return;
+    }
+
+    let updated = existing;
+    if (updated.length > 0 && !updated.endsWith("\n")) {
+      updated += "\n";
+    }
+    if (updated.length > 0 && !updated.endsWith("\n\n")) {
+      updated += "\n";
+    }
+    updated += "# chat.md generated files\n";
+    updated += `${missingEntries.join("\n")}\n`;
+    fs.writeFileSync(gitignorePath, updated, "utf8");
+    log(`Added chat.md generated files to ${gitignorePath}`);
+  } catch (error) {
+    log(`Could not update ${gitignorePath}: ${error}`);
+  }
+}
+
 // --- Helper Function to Select Config by Index ---
 /**
  * Selects and activates the API configuration at the specified index.
@@ -389,6 +444,11 @@ export function activate(contextParam: vscode.ExtensionContext) {
 
   // Call the function that updates the status bar display
   updateStreamingStatusBar(); // Ensure this runs after setting the name
+
+  // Keep generated chat.md files out of repositories by default.
+  for (const workspaceFolder of vscode.workspace.workspaceFolders || []) {
+    ensureChatMdGitignore(workspaceFolder.uri.fsPath);
+  }
 
   // Register for .chat.md files
   const selector: vscode.DocumentSelector = { pattern: "**/*.chat.md" };

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -45,45 +45,9 @@ function countToolExecuteBlocks(text: string): number {
  * same tool call (e.g. the non-fenced match inside a fenced one) are discarded.
  */
 function findAllToolCalls(text: string): string[] {
-  const regexes = [
-    // Properly fenced (opening and closing fence), any language annotation
-    /```(?:[a-zA-Z0-9_\-]*)?(?:\s*\n|\s+)\s*[<]tool_call[>][\s\S]*?\n\s*<\/tool_call>\s*\n\s*```/gs,
-    // Partially fenced (opening fence only)
-    /```(?:[a-zA-Z0-9_\-]*)?(?:\s*\n|\s+)\s*[<]tool_call[>][\s\S]*?\n\s*<\/tool_call>(?!\s*\n\s*```)/gs,
-    // Non-fenced, preceded by a newline
-    /\n\s*[<]tool_call[>][\s\S]*?\n\s*<\/tool_call>/gs,
-    // Non-fenced at the very beginning of the block
-    /^\s*[<]tool_call[>][\s\S]*?\n\s*<\/tool_call>/gs,
-  ];
-
-  const candidates: Array<{ index: number; xml: string; priority: number }> = [];
-  for (let priority = 0; priority < regexes.length; priority++) {
-    const regex = regexes[priority];
-    let match;
-    while ((match = regex.exec(text)) !== null) {
-      candidates.push({ index: match.index, xml: match[0], priority });
-      if (match[0].length === 0) {
-        break; // Safety guard against zero-length matches
-      }
-    }
-  }
-
-  // Earliest first; for matches starting at the same offset the format listed first
-  // wins, so a properly fenced call is preferred over a partially fenced match that
-  // would otherwise run past its own closing fence and swallow the calls after it.
-  candidates.sort((a, b) => a.index - b.index || a.priority - b.priority);
-
-  const toolCalls: string[] = [];
-  let consumedUpto = -1;
-  for (const candidate of candidates) {
-    if (candidate.index < consumedUpto) {
-      continue; // Overlaps a tool call that was already collected
-    }
-    toolCalls.push(candidate.xml);
-    consumedUpto = candidate.index + candidate.xml.length;
-  }
-
-  return toolCalls;
+  const open = "<cmd:tool_call>";
+  const end = "</cmd:tool_call>";
+  return Array.from(text.matchAll(new RegExp(open + "[\\s\\S]*?" + end, "gs")), (m) => m[0]);
 }
 
 /**

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -5,6 +5,7 @@ import {
   hasEmptyToolExecuteBlock,
   ParsedDocumentResult, // Import the return type interface
   findAllAssistantBlocks, // Add this import for resumeStreaming
+  parseAssistantContent,
 } from "./parser";
 import { Lock } from "./utils/lock";
 import { StreamingService } from "./streamer";
@@ -27,6 +28,7 @@ import {
   writeFile, // Keep existing imports
   saveChatHistory, // Keep existing imports
 } from "./utils/fileUtils";
+import { stripThinkingSections } from "./utils/thinkingBlocks";
 
 /**
  * Counts the `# %% tool_execute` block markers in a chunk of text.
@@ -398,7 +400,8 @@ export class DocumentListener {
 
       // Look for tool call XML - the assistant block may contain several tool calls
       // (parallel tool calls), so collect all of them in order of appearance.
-      const toolCalls = findAllToolCalls(assistantResponse);
+      // Thinking sections are excluded: reasoning about a tool call is not a call.
+      const toolCalls = findAllToolCalls(stripThinkingSections(assistantResponse));
 
       if (toolCalls.length === 0) {
         log("No tool call found in assistant response");
@@ -567,7 +570,9 @@ ${JSON.stringify(parsedToolCall.params, null, 2)}
       return 0;
     }
 
-    const toolCalls = findAllToolCalls(lastAssistantMatch[1].trim());
+    const toolCalls = findAllToolCalls(
+      stripThinkingSections(lastAssistantMatch[1].trim()),
+    );
     if (toolCalls.length <= 1) {
       return 0;
     }
@@ -849,27 +854,15 @@ ${JSON.stringify(parsedToolCall.params, null, 2)}
       
       // Check if the last message is from the assistant
       if (updatedMessages.length > 0 && updatedMessages[updatedMessages.length - 1].role === "assistant") {
-        // Append to existing assistant message
-        const existingAssistantContent = updatedMessages[updatedMessages.length - 1].content
-          .filter((c) => c.type === "text")
-          .map((c) => (c as any).value)
-          .join("\n\n");
-        
-        // Replace the content with combined text
-        const newContent: MessageParam["content"] = updatedMessages[updatedMessages.length - 1].content.filter(
-          (c) => c.type !== "text",
-        );
-        newContent.push({
-          type: "text",
-          value: existingAssistantContent + existingContent.trim(),
-        });
-
-        updatedMessages[updatedMessages.length - 1].content = newContent;
+        // parseDocument already parsed this very block (thinking sections included),
+        // so appending the raw block text would duplicate it and leak the "## %%"
+        // markers into the API payload.
+        log("Last parsed message already carries the partial assistant content");
       } else {
         // Add new assistant message with the partial response
         updatedMessages.push({
           role: "assistant",
-          content: [{ type: "text", value: existingContent.trim() }]
+          content: parseAssistantContent(existingContent.trim(), this.document),
         });
       }
     }

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -22,7 +22,7 @@ import * as path from "path";
 import * as fs from "fs"; // Keep fs for file operations
 import { log, mcpClientManager, statusManager, requestStatusBarUpdate } from "./extension"; // Import statusManager and updater
 import { executeToolCall, formatToolResult } from "./tools/toolExecutor"; // Keep existing imports
-import { parseToolCall } from "./tools/toolCallParser"; // Keep existing imports
+import { parseToolCall, findAllToolCalls } from "./tools/toolCallParser"; // Keep existing imports
 import {
   ensureDirectoryExists, // Keep existing imports
   writeFile, // Keep existing imports
@@ -38,17 +38,11 @@ function countToolExecuteBlocks(text: string): number {
   return (text.match(/^# %% tool_execute[ \t]*$/gm) || []).length;
 }
 
-/**
- * Finds every tool call inside an assistant block, in order of appearance.
- * Supports the same formats as the streamer: properly fenced, partially fenced
- * (missing closing fence) and non-fenced tool calls. Overlapping matches of the
- * same tool call (e.g. the non-fenced match inside a fenced one) are discarded.
+/*
+ * Tool calls are collected with findAllToolCalls from tools/toolCallParser, which
+ * shares its pattern with the streaming detector and the parser. Keeping a separate
+ * regex here previously let the listener collect calls that parseToolCall rejected.
  */
-function findAllToolCalls(text: string): string[] {
-  const open = "<cmd:tool_call>";
-  const end = "</cmd:tool_call>";
-  return Array.from(text.matchAll(new RegExp(open + "[\\s\\S]*?" + end, "gs")), (m) => m[0]);
-}
 
 /**
  * Listens for document changes and manages streaming LLM responses.

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -19,7 +19,6 @@ import {
   getDefaultSystemPrompt, // Add function to get default system prompt
 } from "./config";
 import * as path from "path";
-import * as fs from "fs"; // Keep fs for file operations
 import { log, mcpClientManager, statusManager, requestStatusBarUpdate } from "./extension"; // Import statusManager and updater
 import { executeToolCall, formatToolResult } from "./tools/toolExecutor"; // Keep existing imports
 import { parseToolCall, findAllToolCalls } from "./tools/toolCallParser"; // Keep existing imports
@@ -27,6 +26,8 @@ import {
   ensureDirectoryExists, // Keep existing imports
   writeFile, // Keep existing imports
   saveChatHistory, // Keep existing imports
+  getAssetsDirectory,
+  getAssetsRelativePath,
 } from "./utils/fileUtils";
 import { stripThinkingSections } from "./utils/thinkingBlocks";
 
@@ -412,34 +413,6 @@ ${JSON.stringify(parsedToolCall.params, null, 2)}
 \`\`\`
 `;
 
-      // Create a history entry that captures the tool execution process
-      const docDir = path.dirname(this.document.uri.fsPath);
-      const historyDir = path.join(docDir, ".cmd_history");
-      if (!fs.existsSync(historyDir)) {
-        fs.mkdirSync(historyDir, { recursive: true });
-      }
-
-      const timestamp = new Date()
-        .toISOString()
-        .replace(/:/g, "-")
-        .replace(/\..+Z/, "");
-      const executionLogPath = path.join(
-        historyDir,
-        `tool_execution_${timestamp}.md`,
-      );
-
-      // Log pre-execution information
-      let executionLog = `# Tool Call Execution Flow\n\n`;
-      executionLog += `- **Timestamp:** ${new Date().toISOString()}\n`;
-      executionLog += `- **Document:** ${this.document.fileName}\n`;
-      executionLog += `- **Tool Name:** ${parsedToolCall.name}\n\n`;
-
-      executionLog += `## Raw Tool Call XML\n\n\`\`\`xml\n${toolCallXml}\n\`\`\`\n\n`;
-      executionLog += `## Parsed Parameters\n\n\`\`\`json\n${JSON.stringify(parsedToolCall.params, null, 2)}\n\`\`\`\n\n`;
-
-      // Write pre-execution information
-      fs.writeFileSync(executionLogPath, executionLog);
-      log(`Tool execution flow log created: ${executionLogPath}`);
 
       // Execute the tool, passing the raw tool call XML for logging
       const rawResult = await executeToolCall(
@@ -456,25 +429,12 @@ ${JSON.stringify(parsedToolCall.params, null, 2)}
         // Remove the empty tool_execute block
         this.removeLastEmptyBlock("tool_execute");
         
-        // Log cancellation in the execution log file
-        executionLog += `## Tool Execution Cancelled\n\nTool execution was cancelled by user.\n`;
-        fs.writeFileSync(executionLogPath, executionLog);
-        log(`Tool cancellation recorded in log: ${executionLogPath}`);
-        
         // Set status back to idle
         vscode.window.showInformationMessage("Tool execution cancelled, but it may still have gone through successfully");
         
         // Don't insert anything into the document
         return;
       }
-
-      // Append the result to the execution log
-      const loggedToolResult = typeof rawResult === "string"
-        ? rawResult
-        : JSON.stringify(rawResult, null, 2);
-      executionLog += `## Tool Execution Result\n\n\`\`\`\n${loggedToolResult}\n\`\`\`\n`;
-      fs.writeFileSync(executionLogPath, executionLog);
-      log(`Tool execution result appended to log: ${executionLogPath}`);
 
       // Insert the raw result (insertToolResult will handle formatting/linking)
       await this.insertToolResult(rawResult);
@@ -575,7 +535,7 @@ ${JSON.stringify(parsedToolCall.params, null, 2)}
       if (lines.length > lineCountThreshold) {
         log(`Formatted rich result exceeds ${lineCountThreshold} lines, saving to file.`);
         try {
-          const assetsDir = path.join(docDir, "cmdassets");
+          const assetsDir = getAssetsDirectory(docDir);
           ensureDirectoryExists(assetsDir);
 
           const timestamp = new Date()
@@ -586,7 +546,7 @@ ${JSON.stringify(parsedToolCall.params, null, 2)}
             .replace(/\..+Z/, "");
           const randomString = Math.random().toString(36).substring(2, 8);
           const filename = `tool-result-${timestamp}-${randomString}.md`;
-          const relativeFilePath = path.join("cmdassets", filename);
+          const relativeFilePath = getAssetsRelativePath(docDir, filename);
           const fullFilePath = path.join(assetsDir, filename);
 
           writeFile(fullFilePath, formattedMarkdown);
@@ -619,7 +579,7 @@ ${JSON.stringify(parsedToolCall.params, null, 2)}
           log(`Result exceeds ${lineCountThreshold} lines, saving to file.`);
           try {
             const docDir = path.dirname(this.document.uri.fsPath);
-            const assetsDir = path.join(docDir, "cmdassets");
+            const assetsDir = getAssetsDirectory(docDir);
             ensureDirectoryExists(assetsDir);
 
             const timestamp = new Date()
@@ -630,7 +590,7 @@ ${JSON.stringify(parsedToolCall.params, null, 2)}
               .replace(/\..+Z/, "");
             const randomString = Math.random().toString(36).substring(2, 8);
             const filename = `tool-result-${timestamp}-${randomString}.txt`;
-            const relativeFilePath = path.join("cmdassets", filename);
+            const relativeFilePath = getAssetsRelativePath(docDir, filename);
             const fullFilePath = path.join(assetsDir, filename);
 
             writeFile(fullFilePath, rawResult);
@@ -991,6 +951,17 @@ ${JSON.stringify(parsedToolCall.params, null, 2)}
         messages,
         "before_llm_call",
         finalSystemPrompt, // Use the combined prompt
+        {
+          provider: perFileConfigName
+            ? require("./config").getProviderForConfig(perFileConfigName)
+            : require("./config").getProvider(),
+          model: perFileConfigName
+            ? require("./config").getModelNameForConfig(perFileConfigName)
+            : require("./config").getModelName(),
+          config: perFileConfigName
+            ? perFileConfigName
+            : require("./config").getSelectedConfigName(),
+        },
       );
       log(`Saved chat history (before call) to: ${historyFilePath}`);
 

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -19,7 +19,13 @@ import {
   getDefaultSystemPrompt, // Add function to get default system prompt
 } from "./config";
 import * as path from "path";
-import { log, mcpClientManager, statusManager, requestStatusBarUpdate } from "./extension"; // Import statusManager and updater
+import {
+  ensureChatMdGitignore,
+  log,
+  mcpClientManager,
+  statusManager,
+  requestStatusBarUpdate,
+} from "./extension";
 import { executeToolCall, formatToolResult } from "./tools/toolExecutor"; // Keep existing imports
 import { parseToolCall, findAllToolCalls } from "./tools/toolCallParser"; // Keep existing imports
 import {
@@ -874,6 +880,12 @@ ${JSON.stringify(parsedToolCall.params, null, 2)}
    * Start streaming response from LLM. Handles parsing, errors, prompt assembly, and initiation.
    */
   private async startStreaming(): Promise<void> {
+    // Keep generated files ignored in the Git repository containing this chat file.
+    // Do not let Git discovery or .gitignore I/O delay the API request.
+    void Promise.resolve().then(() =>
+      ensureChatMdGitignore(path.dirname(this.document.uri.fsPath)),
+    );
+
     // Prevent concurrent streams for the same document
     const activeStreamer = this.getActiveStreamer();
     if (activeStreamer) {

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -29,6 +29,62 @@ import {
 } from "./utils/fileUtils";
 
 /**
+ * Counts the `# %% tool_execute` block markers in a chunk of text.
+ * Used to figure out how many tool calls of an assistant block already ran.
+ */
+function countToolExecuteBlocks(text: string): number {
+  return (text.match(/^# %% tool_execute[ \t]*$/gm) || []).length;
+}
+
+/**
+ * Finds every tool call inside an assistant block, in order of appearance.
+ * Supports the same formats as the streamer: properly fenced, partially fenced
+ * (missing closing fence) and non-fenced tool calls. Overlapping matches of the
+ * same tool call (e.g. the non-fenced match inside a fenced one) are discarded.
+ */
+function findAllToolCalls(text: string): string[] {
+  const regexes = [
+    // Properly fenced (opening and closing fence), any language annotation
+    /```(?:[a-zA-Z0-9_\-]*)?(?:\s*\n|\s+)\s*[<]tool_call[>][\s\S]*?\n\s*<\/tool_call>\s*\n\s*```/gs,
+    // Partially fenced (opening fence only)
+    /```(?:[a-zA-Z0-9_\-]*)?(?:\s*\n|\s+)\s*[<]tool_call[>][\s\S]*?\n\s*<\/tool_call>(?!\s*\n\s*```)/gs,
+    // Non-fenced, preceded by a newline
+    /\n\s*[<]tool_call[>][\s\S]*?\n\s*<\/tool_call>/gs,
+    // Non-fenced at the very beginning of the block
+    /^\s*[<]tool_call[>][\s\S]*?\n\s*<\/tool_call>/gs,
+  ];
+
+  const candidates: Array<{ index: number; xml: string; priority: number }> = [];
+  for (let priority = 0; priority < regexes.length; priority++) {
+    const regex = regexes[priority];
+    let match;
+    while ((match = regex.exec(text)) !== null) {
+      candidates.push({ index: match.index, xml: match[0], priority });
+      if (match[0].length === 0) {
+        break; // Safety guard against zero-length matches
+      }
+    }
+  }
+
+  // Earliest first; for matches starting at the same offset the format listed first
+  // wins, so a properly fenced call is preferred over a partially fenced match that
+  // would otherwise run past its own closing fence and swallow the calls after it.
+  candidates.sort((a, b) => a.index - b.index || a.priority - b.priority);
+
+  const toolCalls: string[] = [];
+  let consumedUpto = -1;
+  for (const candidate of candidates) {
+    if (candidate.index < consumedUpto) {
+      continue; // Overlaps a tool call that was already collected
+    }
+    toolCalls.push(candidate.xml);
+    consumedUpto = candidate.index + candidate.xml.length;
+  }
+
+  return toolCalls;
+}
+
+/**
  * Listens for document changes and manages streaming LLM responses.
  * Handles system prompt aggregation, image errors, and triggering actions.
  */
@@ -340,90 +396,11 @@ export class DocumentListener {
         `Found assistant response: "${assistantResponse.substring(0, 100)}${assistantResponse.length > 100 ? "..." : ""}"`,
       );
 
-      // Look for tool call XML - find the LAST match instead of first
-      // Support both fenced and non-fenced tool calls
+      // Look for tool call XML - the assistant block may contain several tool calls
+      // (parallel tool calls), so collect all of them in order of appearance.
+      const toolCalls = findAllToolCalls(assistantResponse);
 
-      // Match for properly fenced tool calls (with opening and closing fences)
-      // Allow for any annotation after the triple backticks
-      const properlyFencedToolCallRegex =
-        /```(?:[a-zA-Z0-9_\-]*)?(?:\s*\n|\s+)\s*<tool_call>[\s\S]*?\n\s*<\/tool_call>\s*\n\s*```/gs;
-
-      // Match for partially fenced tool calls (with opening fence but missing closing fence)
-      // Allow for any annotation after the triple backticks
-      const partiallyFencedToolCallRegex =
-        /```(?:[a-zA-Z0-9_\-]*)?(?:\s*\n|\s+)\s*<tool_call>[\s\S]*?\n\s*<\/tool_call>(?!\s*\n\s*```)/gs;
-
-      // Match for non-fenced tool calls
-      const nonFencedToolCallRegex =
-        /\n\s*<tool_call>[\s\S]*?\n\s*<\/tool_call>/gs;
-
-      // Find all matches for all patterns
-      let properlyFencedMatch;
-      let lastProperlyFencedMatch = null;
-      let partiallyFencedMatch;
-      let lastPartiallyFencedMatch = null;
-      let nonFencedMatch;
-      let lastNonFencedMatch = null;
-
-      // Find all properly fenced matches
-      while (
-        (properlyFencedMatch =
-          properlyFencedToolCallRegex.exec(assistantResponse)) !== null
-      ) {
-        lastProperlyFencedMatch = properlyFencedMatch;
-      }
-
-      // Find all partially fenced matches
-      while (
-        (partiallyFencedMatch =
-          partiallyFencedToolCallRegex.exec(assistantResponse)) !== null
-      ) {
-        lastPartiallyFencedMatch = partiallyFencedMatch;
-      }
-
-      // Find all non-fenced matches
-      while (
-        (nonFencedMatch = nonFencedToolCallRegex.exec(assistantResponse)) !==
-        null
-      ) {
-        lastNonFencedMatch = nonFencedMatch;
-      }
-
-      // Determine which match to use (last one found, prioritizing in order: properly fenced, partially fenced, non-fenced)
-      let toolCallMatch = null;
-
-      // Find the last position of any match
-      const positions = [];
-      if (lastProperlyFencedMatch)
-        positions.push({
-          type: "properly-fenced",
-          match: lastProperlyFencedMatch,
-          index: lastProperlyFencedMatch.index,
-        });
-      if (lastPartiallyFencedMatch)
-        positions.push({
-          type: "partially-fenced",
-          match: lastPartiallyFencedMatch,
-          index: lastPartiallyFencedMatch.index,
-        });
-      if (lastNonFencedMatch)
-        positions.push({
-          type: "non-fenced",
-          match: lastNonFencedMatch,
-          index: lastNonFencedMatch.index,
-        });
-
-      // Sort by position in descending order (last in the text first)
-      positions.sort((a, b) => b.index - a.index);
-
-      if (positions.length > 0) {
-        toolCallMatch = positions[0].match;
-        log(
-          `Using last ${positions[0].type} tool call at position ${positions[0].index}`,
-        );
-      }
-
-      if (!toolCallMatch) {
+      if (toolCalls.length === 0) {
         log("No tool call found in assistant response");
         const errorResult = formatToolResult(
           "Error: No tool call found in assistant response",
@@ -432,7 +409,19 @@ export class DocumentListener {
         return;
       }
 
-      const toolCallXml = toolCallMatch[0];
+      // Each tool call gets its own tool_execute block, matched up positionally:
+      // the number of tool_execute blocks already present between the assistant
+      // block and this empty one tells us which tool call to run now.
+      const assistantBlockEnd = lastMatch.index + lastMatch[0].length;
+      const alreadyExecuted = countToolExecuteBlocks(
+        text.substring(assistantBlockEnd, toolExecutePosition),
+      );
+      const toolCallIndex = Math.min(alreadyExecuted, toolCalls.length - 1);
+      log(
+        `Assistant block contains ${toolCalls.length} tool call(s), ${alreadyExecuted} already executed, executing #${toolCallIndex + 1}`,
+      );
+
+      const toolCallXml = toolCalls[toolCallIndex];
       log(
         `Found tool call: "${toolCallXml.substring(0, 100)}${toolCallXml.length > 100 ? "..." : ""}"`,
       );
@@ -554,6 +543,44 @@ ${JSON.stringify(parsedToolCall.params, null, 2)}
         requestStatusBarUpdate(this.document.uri.fsPath, "tool execution finished");
       } catch {}
     }
+  }
+
+  /**
+   * Counts how many tool calls of the assistant block governing the given
+   * tool_execute block still need to be executed, treating the block at
+   * `toolExecutePosition` as the one being executed right now.
+   */
+  private countPendingToolCalls(
+    text: string,
+    toolExecutePosition: number,
+  ): number {
+    const textBefore = text.substring(0, toolExecutePosition);
+    const assistantBlockRegex = /# %% assistant\s+([\s\S]*?)(?=\n# %%|$)/g;
+
+    let match;
+    let lastAssistantMatch: RegExpExecArray | null = null;
+    while ((match = assistantBlockRegex.exec(textBefore)) !== null) {
+      lastAssistantMatch = match;
+    }
+
+    if (!lastAssistantMatch) {
+      return 0;
+    }
+
+    const toolCalls = findAllToolCalls(lastAssistantMatch[1].trim());
+    if (toolCalls.length <= 1) {
+      return 0;
+    }
+
+    const assistantBlockEnd =
+      lastAssistantMatch.index + lastAssistantMatch[0].length;
+    // Tool_execute blocks before this one, plus the one being filled right now
+    const executed =
+      countToolExecuteBlocks(
+        text.substring(assistantBlockEnd, toolExecutePosition),
+      ) + 1;
+
+    return Math.max(0, toolCalls.length - executed);
   }
 
   /**
@@ -712,7 +739,23 @@ ${JSON.stringify(parsedToolCall.params, null, 2)}
       `Calculated insertion range: Start(${startPos.line},${startPos.character}), End(${endPos.line},${endPos.character})`,
     );
 
-    // Create an edit that replaces the empty content with the result and adds a new assistant block after
+    // Create an edit that replaces the empty content with the result, followed by the
+    // next block. With parallel tool calls the same assistant block can hold several
+    // tool calls, so if any of them are still pending we add another tool_execute
+    // block instead of an assistant block, and only start the next API call once all
+    // of them have been executed.
+    const pendingToolCalls = this.countPendingToolCalls(
+      text,
+      lastEmptyBlock.position,
+    );
+    const nextBlockMarker =
+      pendingToolCalls > 0 ? "# %% tool_execute" : "# %% assistant";
+    if (pendingToolCalls > 0) {
+      log(
+        `${pendingToolCalls} tool call(s) still pending in the assistant block, adding another tool_execute block`,
+      );
+    }
+
     const resultText = typeof rawResult === "string" ? rawResult : "";
     const isMarkdownLink =
       shouldInsertAsMarkdown ||
@@ -720,10 +763,10 @@ ${JSON.stringify(parsedToolCall.params, null, 2)}
 
     let textToInsert;
     if (isMarkdownLink) {
-      textToInsert = `\n${contentToInsert.trim()}\n\n# %% assistant\n`;
+      textToInsert = `\n${contentToInsert.trim()}\n\n${nextBlockMarker}\n`;
       log("Inserting markdown result without code fences");
     } else {
-      textToInsert = `\n\`\`\`\n${contentToInsert.trim()}\n\`\`\`\n\n# %% assistant\n`;
+      textToInsert = `\n\`\`\`\n${contentToInsert.trim()}\n\`\`\`\n\n${nextBlockMarker}\n`;
       log("Inserting plain text content with code fences");
     }
     // If the block wasn't just the marker but had whitespace, adjust insertion

--- a/src/openaiClient.ts
+++ b/src/openaiClient.ts
@@ -86,6 +86,7 @@ class ReasoningDetailsAccumulator {
  * Client for communicating with the OpenAI API
  */
 export class OpenAIClient {
+  public lastUsage: Record<string, unknown> | undefined;
   private readonly apiUrl: string;
 
   constructor(
@@ -129,6 +130,7 @@ export class OpenAIClient {
     configName?: string,
     fileConfig?: Record<string, any>,
   ): AsyncGenerator<string[], void, unknown> {
+    this.lastUsage = undefined;
     log(`Starting OpenAI API request with ${messages.length} messages`);
 
     try {
@@ -175,6 +177,7 @@ export class OpenAIClient {
         model: modelName,
         messages: allMessages,
         stream: true,
+        stream_options: { include_usage: true },
       };
 
       // Add reasoning_effort parameter if configured
@@ -443,6 +446,13 @@ export class OpenAIClient {
               if (jsonData.trim()) {
                 try {
                   const data = JSON.parse(jsonData);
+                  if (data.usage) {
+                    this.lastUsage = {
+                      inputTokens: data.usage.prompt_tokens,
+                      outputTokens: data.usage.completion_tokens,
+                      cacheReadTokens: data.usage.prompt_tokens_details?.cached_tokens,
+                    };
+                  }
 
                   // OpenAI's format has choices with delta that contains content
                   if (data.choices && data.choices.length > 0) {

--- a/src/openaiClient.ts
+++ b/src/openaiClient.ts
@@ -355,15 +355,17 @@ export class OpenAIClient {
         }
       }
 
-      // Only process reasoning_details when no text field carried the same
-      // text in this delta. Some providers (e.g. OpenRouter) send both
-      // "reasoning_content" and "reasoning_details" with identical content,
-      // which would duplicate every reasoning chunk.
-      if (!foundTextField && Array.isArray(delta.reasoning_details)) {
+      // reasoning_details is always accumulated, because it is the only form that
+      // can be replayed verbatim on the next turn (it carries provider signatures
+      // that flat reasoning text does not). Its text is only *displayed* when no
+      // text field already carried it: some providers (e.g. OpenRouter) send both
+      // "reasoning_content" and "reasoning_details" with identical content, which
+      // would otherwise duplicate every reasoning chunk in the document.
+      if (Array.isArray(delta.reasoning_details)) {
         for (const detail of delta.reasoning_details) {
           const text = reasoningAccumulator.processDelta(detail);
           reasoningOpen = true;
-          if (text) {
+          if (text && !foundTextField) {
             reasoningText += text;
             tokens.push(encodeThinkingToken(text));
           }

--- a/src/openaiClient.ts
+++ b/src/openaiClient.ts
@@ -2,7 +2,7 @@ import * as https from "https";
 import * as http from "http";
 import * as path from "path";
 import * as url from "url";
-import { MessageParam, Content } from "./types";
+import { MessageParam, Content, ThinkingPayload } from "./types";
 import { resolveFilePath, readFileAsBuffer } from "./utils/fileUtils";
 import * as vscode from "vscode";
 import { log } from "./extension";
@@ -11,6 +11,76 @@ import {
   getBaseUrl,
   generateToolCallingSystemPrompt,
 } from "./config";
+import {
+  encodeThinkingPayloadToken,
+  encodeThinkingToken,
+} from "./utils/thinkingBlocks";
+import { cleanMessagesForApi } from "./utils/messageCleanup";
+
+/**
+ * Accumulates OpenRouter style reasoning_details deltas so the full array can be
+ * replayed on the next turn. Modelled on llm-codegen's ReasoningDetailsAccumulator.
+ */
+class ReasoningDetailsAccumulator {
+  private readonly details: any[] = [];
+  private readonly indexes = new Map<string, number>();
+
+  public processDelta(detail: any): string {
+    if (!detail || typeof detail !== "object") {
+      return "";
+    }
+
+    const displayText = this.displayText(detail);
+    const key = this.keyFor(detail, this.details.length);
+    const existingIndex = this.indexes.get(key);
+
+    if (existingIndex === undefined) {
+      this.indexes.set(key, this.details.length);
+      this.details.push({ ...detail });
+      return displayText;
+    }
+
+    const existing = this.details[existingIndex];
+    for (const [field, value] of Object.entries(detail)) {
+      if ((field === "text" || field === "summary") && typeof value === "string") {
+        existing[field] =
+          typeof existing[field] === "string" ? existing[field] + value : value;
+      } else if (value !== null && value !== undefined) {
+        existing[field] = value;
+      }
+    }
+    return displayText;
+  }
+
+  public hasDetails(): boolean {
+    return this.details.length > 0;
+  }
+
+  public getDetails(): any[] {
+    return JSON.parse(JSON.stringify(this.details));
+  }
+
+  private keyFor(detail: any, fallbackIndex: number): string {
+    const type = typeof detail.type === "string" ? detail.type : "reasoning.unknown";
+    if (typeof detail.id === "string" && detail.id) {
+      return `${type}::id::${detail.id}`;
+    }
+    if (typeof detail.index === "number") {
+      return `${type}::index::${detail.index}`;
+    }
+    return `${type}::pos::${fallbackIndex}`;
+  }
+
+  private displayText(detail: any): string {
+    if (typeof detail.text === "string") {
+      return detail.text;
+    }
+    if (typeof detail.summary === "string") {
+      return detail.summary;
+    }
+    return "";
+  }
+}
 
 /**
  * Client for communicating with the OpenAI API
@@ -67,12 +137,6 @@ export class OpenAIClient {
         systemPrompt || generateToolCallingSystemPrompt(new Map(), new Map());
       const systemMessage = { role: "system", content: systemPromptToUse };
 
-      // Format regular messages
-      const formattedMessages = this.formatMessages(messages, document);
-
-      // Add system message as the first message
-      const allMessages = [systemMessage, ...formattedMessages];
-
       // Resolve model name (allow per-file override)
       let modelName = modelNameOverride;
       if (!modelName) {
@@ -92,7 +156,20 @@ export class OpenAIClient {
       const { getMaxTokens, getReasoningEffort } = require("./config");
       const maxTokens = getMaxTokens(configName, fileConfig);
       const reasoningEffort = getReasoningEffort(configName, fileConfig);
-      
+
+      // Reasoning is replayed unless it was explicitly turned off
+      const cleanedMessages = cleanMessagesForApi(messages, {
+        modelName,
+        thinkingEnabled: reasoningEffort !== "none",
+        apiStyle: "openai_chat",
+      });
+
+      // Add system message as the first message
+      const allMessages = [
+        systemMessage,
+        ...this.formatMessages(cleanedMessages, document),
+      ];
+
       // Initial request body
       const requestBody: any = {
         model: modelName,
@@ -190,7 +267,7 @@ export class OpenAIClient {
       }
 
       log("Processing streaming response from OpenAI");
-      yield* this.createStreamGenerator(response);
+      yield* this.createStreamGenerator(response, modelName);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       log(`Error in streamCompletion: ${message}`);
@@ -207,9 +284,84 @@ export class OpenAIClient {
    */
   private async *createStreamGenerator(
     response: http.IncomingMessage,
+    modelName: string,
   ): AsyncGenerator<string[], void, unknown> {
     let buffer = "";
     let eventCount = 0;
+
+    // Reasoning state for the current assistant turn
+    let reasoningAccumulator = new ReasoningDetailsAccumulator();
+    let reasoningText = "";
+    let reasoningField: "reasoning" | "reasoning_content" | "reasoning_summary" =
+      "reasoning_content";
+    let reasoningOpen = false;
+
+    /**
+     * Builds the payload token that closes the current reasoning run. Returns an
+     * empty array when there is no open reasoning.
+     */
+    const closeReasoning = (): string[] => {
+      if (!reasoningOpen) {
+        return [];
+      }
+      reasoningOpen = false;
+
+      const payload: ThinkingPayload & { model: string } =
+        reasoningAccumulator.hasDetails()
+          ? {
+              model: modelName,
+              kind: "reasoning_details",
+              reasoningDetails: reasoningAccumulator.getDetails(),
+            }
+          : {
+              model: modelName,
+              kind: "raw",
+              field: reasoningField,
+            };
+
+      reasoningAccumulator = new ReasoningDetailsAccumulator();
+      reasoningText = "";
+      return [encodeThinkingPayloadToken(payload)];
+    };
+
+    /**
+     * Extracts reasoning from a streaming delta. Providers disagree on the field
+     * name, and OpenRouter sends structured reasoning_details.
+     */
+    const readReasoning = (delta: any): string[] => {
+      if (!delta) {
+        return [];
+      }
+
+      const tokens: string[] = [];
+
+      for (const field of [
+        "reasoning_content",
+        "reasoning",
+        "reasoning_summary",
+      ] as const) {
+        const value = delta[field];
+        if (typeof value === "string" && value) {
+          reasoningField = field;
+          reasoningOpen = true;
+          reasoningText += value;
+          tokens.push(encodeThinkingToken(value));
+        }
+      }
+
+      if (Array.isArray(delta.reasoning_details)) {
+        for (const detail of delta.reasoning_details) {
+          const text = reasoningAccumulator.processDelta(detail);
+          reasoningOpen = true;
+          if (text) {
+            reasoningText += text;
+            tokens.push(encodeThinkingToken(text));
+          }
+        }
+      }
+
+      return tokens;
+    };
 
     // Keep track of the last chunks for debugging
     const lastChunks = [];
@@ -283,6 +435,18 @@ export class OpenAIClient {
                   // OpenAI's format has choices with delta that contains content
                   if (data.choices && data.choices.length > 0) {
                     const choice = data.choices[0];
+
+                    // Reasoning deltas arrive before content on reasoning models
+                    const reasoningTokens = readReasoning(choice.delta);
+                    if (reasoningTokens.length > 0) {
+                      eventCount++;
+                      yield reasoningTokens;
+                    }
+
+                    // The first content delta closes the reasoning run
+                    if (choice.delta && choice.delta.content && reasoningOpen) {
+                      yield closeReasoning();
+                    }
 
                     // Check for finish_reason="length" which indicates max tokens reached
                     if (choice.finish_reason === "length") {
@@ -386,6 +550,11 @@ export class OpenAIClient {
         }
       }
 
+      // Reasoning that was never followed by content still needs its payload
+      if (reasoningOpen) {
+        yield closeReasoning();
+      }
+
       log(`Stream completed, processed ${eventCount} events`);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -417,10 +586,31 @@ export class OpenAIClient {
     messages: readonly MessageParam[],
     document?: vscode.TextDocument,
   ): any[] {
-    return messages.map((msg) => ({
-      role: msg.role,
-      content: this.formatContent(msg.content, document),
-    }));
+    return messages.map((msg) => {
+      const thinking = msg.content.find((block) => block.type === "thinking");
+      const rest = msg.content.filter((block) => block.type !== "thinking");
+      const formatted: any = {
+        role: msg.role,
+        content: this.formatContent(
+          rest.length > 0 ? rest : [{ type: "text", value: "" }],
+          document,
+        ),
+      };
+
+      // Reasoning travels in top level fields on the assistant message, never in
+      // the content array (see llm-codegen openai_wrapper).
+      if (thinking && thinking.type === "thinking" && msg.role === "assistant") {
+        const payload = thinking.payload;
+        if (payload?.kind === "reasoning_details" && payload.reasoningDetails) {
+          formatted.reasoning_details = payload.reasoningDetails;
+        } else if (thinking.value.trim() !== "") {
+          const field = payload?.field ?? "reasoning_content";
+          formatted[field] = thinking.value;
+        }
+      }
+
+      return formatted;
+    });
   }
 
   /**

--- a/src/openaiClient.ts
+++ b/src/openaiClient.ts
@@ -335,6 +335,10 @@ export class OpenAIClient {
 
       const tokens: string[] = [];
 
+      // Providers sometimes send the same reasoning in multiple fields at
+      // once (e.g. both "reasoning" and "reasoning_content"). Pick the first
+      // field that has content and ignore the rest to avoid duplicates.
+      let foundTextField = false;
       for (const field of [
         "reasoning_content",
         "reasoning",
@@ -346,10 +350,16 @@ export class OpenAIClient {
           reasoningOpen = true;
           reasoningText += value;
           tokens.push(encodeThinkingToken(value));
+          foundTextField = true;
+          break;
         }
       }
 
-      if (Array.isArray(delta.reasoning_details)) {
+      // Only process reasoning_details when no text field carried the same
+      // text in this delta. Some providers (e.g. OpenRouter) send both
+      // "reasoning_content" and "reasoning_details" with identical content,
+      // which would duplicate every reasoning chunk.
+      if (!foundTextField && Array.isArray(delta.reasoning_details)) {
         for (const detail of delta.reasoning_details) {
           const text = reasoningAccumulator.processDelta(detail);
           reasoningOpen = true;

--- a/src/openaiClient.ts
+++ b/src/openaiClient.ts
@@ -19,7 +19,7 @@ import { cleanMessagesForApi } from "./utils/messageCleanup";
 
 /**
  * Accumulates OpenRouter style reasoning_details deltas so the full array can be
- * replayed on the next turn. Modelled on llm-codegen's ReasoningDetailsAccumulator.
+ * replayed on the next turn using an accumulator for provider reasoning details.
  */
 class ReasoningDetailsAccumulator {
   private readonly details: any[] = [];
@@ -620,7 +620,7 @@ export class OpenAIClient {
       };
 
       // Reasoning travels in top level fields on the assistant message, never in
-      // the content array (see llm-codegen openai_wrapper).
+      // the content array, using the provider's top-level reasoning fields.
       if (thinking && thinking.type === "thinking" && msg.role === "assistant") {
         const payload = thinking.payload;
         if (payload?.kind === "reasoning_details" && payload.reasoningDetails) {

--- a/src/openaiResponsesClient.ts
+++ b/src/openaiResponsesClient.ts
@@ -1,0 +1,416 @@
+import * as https from "https";
+import * as http from "http";
+import * as path from "path";
+import { MessageParam, Content, ThinkingPayload } from "./types";
+import { resolveFilePath, readFileAsBuffer } from "./utils/fileUtils";
+import * as vscode from "vscode";
+import { log } from "./extension";
+import { generateToolCallingSystemPrompt } from "./config";
+import {
+  encodeThinkingPayloadToken,
+  encodeThinkingToken,
+} from "./utils/thinkingBlocks";
+import { cleanMessagesForApi } from "./utils/messageCleanup";
+
+/**
+ * Client for the OpenAI Responses API.
+ *
+ * Requests are stateless (store: false) and ask for encrypted reasoning so the
+ * reasoning items can be replayed on later turns, which is the only way to keep
+ * reasoning context on gpt-* and o-series models.
+ */
+export class OpenAIResponsesClient {
+  private readonly apiUrl: string;
+
+  constructor(
+    private readonly apiKey: string,
+    private readonly customBaseUrl?: string,
+  ) {
+    if (this.customBaseUrl) {
+      if (this.customBaseUrl.includes("/responses")) {
+        this.apiUrl = this.customBaseUrl;
+      } else {
+        this.apiUrl = this.joinUrl(this.customBaseUrl, "/responses");
+      }
+    } else {
+      this.apiUrl = "https://api.openai.com/v1/responses";
+    }
+    log(`Using OpenAI Responses API URL: ${this.apiUrl}`);
+  }
+
+  private joinUrl(baseUrl: string, suffix: string): string {
+    const base = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
+    const cleanSuffix = suffix.startsWith("/") ? suffix : "/" + suffix;
+    return base + cleanSuffix;
+  }
+
+  public async *streamCompletion(
+    messages: readonly MessageParam[],
+    document?: vscode.TextDocument,
+    systemPrompt?: string,
+    modelNameOverride?: string,
+    configName?: string,
+    fileConfig?: Record<string, any>,
+  ): AsyncGenerator<string[], void, unknown> {
+    log(`Starting OpenAI Responses request with ${messages.length} messages`);
+
+    try {
+      let modelName = modelNameOverride;
+      if (!modelName) {
+        try {
+          const { getModelName } = require("./config");
+          modelName = getModelName();
+        } catch (e) {
+          log(`Error getting model name: ${e}`);
+          modelName = undefined;
+        }
+      }
+      modelName = modelName || "gpt-4.1-mini";
+
+      const systemPromptToUse =
+        systemPrompt || generateToolCallingSystemPrompt(new Map(), new Map());
+
+      const { getMaxTokens, getReasoningEffort } = require("./config");
+      const maxTokens = getMaxTokens(configName, fileConfig);
+      const reasoningEffort = getReasoningEffort(configName, fileConfig);
+      const thinkingEnabled = reasoningEffort !== "none";
+
+      const cleanedMessages = cleanMessagesForApi(messages, {
+        modelName,
+        thinkingEnabled,
+        apiStyle: "openai_responses",
+      });
+
+      const requestBody: any = {
+        model: modelName,
+        input: this.convertToResponsesInput(cleanedMessages, document),
+        instructions: systemPromptToUse,
+        max_output_tokens: maxTokens,
+        stream: true,
+        // Stateless: chat.md keeps the whole conversation in the document
+        store: false,
+      };
+
+      if (thinkingEnabled) {
+        const reasoning: any = { summary: "auto" };
+        if (reasoningEffort) {
+          reasoning.effort = reasoningEffort;
+        }
+        requestBody.reasoning = reasoning;
+        // Without this the encrypted reasoning cannot be replayed later
+        requestBody.include = ["reasoning.encrypted_content"];
+        log(`Using Responses reasoning config: ${JSON.stringify(reasoning)}`);
+      }
+
+      log(`Using OpenAI Responses model: ${modelName}`);
+
+      const parsedUrl = new URL(this.apiUrl);
+      const requestOptions = {
+        method: "POST",
+        hostname: parsedUrl.hostname,
+        port: parsedUrl.port || (parsedUrl.protocol === "https:" ? 443 : 80),
+        path: parsedUrl.pathname + parsedUrl.search,
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+      };
+
+      const requester = parsedUrl.protocol === "https:" ? https : http;
+      const req = requester.request(requestOptions);
+
+      req.on("error", (error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        log(`Responses API request error: ${message}`);
+        vscode.window.showErrorMessage(
+          `OpenAI Responses API request error: ${message}`,
+        );
+        throw error;
+      });
+
+      req.write(JSON.stringify(requestBody));
+      req.end();
+
+      const response = await new Promise<http.IncomingMessage>(
+        (resolve, reject) => {
+          req.on("response", resolve);
+          req.on("error", reject);
+        },
+      );
+
+      log(`Responses API status code: ${response.statusCode}`);
+
+      if (response.statusCode !== 200) {
+        let errorData = "";
+        for await (const chunk of response) {
+          errorData += chunk.toString();
+        }
+
+        const errorMessage = `${response.statusCode} - API request failed: ${errorData}`;
+        log(errorMessage);
+
+        if (response.statusCode! >= 500) {
+          vscode.window.showErrorMessage(
+            `OpenAI Responses API Server Error (${response.statusCode}): Will automatically retry`,
+          );
+        } else if (response.statusCode === 429) {
+          vscode.window.showErrorMessage(
+            `OpenAI Responses API Rate Limit (${response.statusCode}): Will automatically retry with backoff`,
+          );
+        } else {
+          vscode.window.showErrorMessage(
+            `OpenAI Responses API Error (${response.statusCode}): ${errorData || "Failed to get error details"}`,
+          );
+        }
+
+        throw new Error(errorMessage);
+      }
+
+      yield* this.createStreamGenerator(response, modelName);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log(`Error in Responses streamCompletion: ${message}`);
+      if (!message.includes("max_output_tokens")) {
+        vscode.window.showErrorMessage(
+          `Failed to initiate OpenAI Responses stream: ${message}`,
+        );
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Processes the Responses SSE stream.
+   *
+   * Text arrives as response.output_text.delta, reasoning summaries as
+   * response.reasoning_summary_text.delta, and the encrypted payload only shows up
+   * when the reasoning item is done.
+   */
+  private async *createStreamGenerator(
+    response: http.IncomingMessage,
+    modelName: string,
+  ): AsyncGenerator<string[], void, unknown> {
+    let buffer = "";
+    let eventCount = 0;
+
+    try {
+      for await (const chunk of response) {
+        buffer += chunk.toString();
+
+        while (true) {
+          const eventEnd = buffer.indexOf("\n\n");
+          if (eventEnd === -1) {
+            break;
+          }
+
+          const rawEvent = buffer.substring(0, eventEnd);
+          buffer = buffer.substring(eventEnd + 2);
+
+          const dataLine = rawEvent
+            .split(/\r?\n/)
+            .find((line) => line.startsWith("data: "));
+          if (!dataLine) {
+            continue;
+          }
+
+          const jsonData = dataLine.substring(6).trim();
+          if (!jsonData || jsonData === "[DONE]") {
+            continue;
+          }
+
+          let data: any;
+          try {
+            data = JSON.parse(jsonData);
+          } catch (e) {
+            log(`Responses API: could not parse event data: ${e}`);
+            continue;
+          }
+
+          eventCount++;
+
+          switch (data.type) {
+            case "response.output_text.delta": {
+              if (typeof data.delta === "string" && data.delta) {
+                yield [data.delta];
+              }
+              break;
+            }
+            case "response.reasoning_summary_text.delta":
+            case "response.reasoning_text.delta": {
+              if (typeof data.delta === "string" && data.delta) {
+                yield [encodeThinkingToken(data.delta)];
+              }
+              break;
+            }
+            case "response.output_item.done": {
+              const item = data.item;
+              if (item && item.type === "reasoning" && item.encrypted_content) {
+                const payload: ThinkingPayload & { model: string } = {
+                  model: modelName,
+                  kind: "openai_encrypted",
+                  itemId: item.id,
+                  encryptedContent: item.encrypted_content,
+                };
+                log(`Received encrypted reasoning item ${item.id}`);
+                yield [encodeThinkingPayloadToken(payload)];
+              }
+              break;
+            }
+            case "response.incomplete": {
+              const reason = data.response?.incomplete_details?.reason;
+              log(`Responses API incomplete: ${reason}`);
+              if (reason === "max_output_tokens") {
+                throw new Error(
+                  "max_output_tokens: Response incomplete due to token limit",
+                );
+              }
+              break;
+            }
+            case "response.failed":
+            case "error": {
+              const message =
+                data.response?.error?.message || data.message || "unknown error";
+              log(`Responses API error event: ${message}`);
+              throw new Error(`Responses API error: ${message}`);
+            }
+            default:
+              break;
+          }
+        }
+      }
+
+      log(`Responses stream completed, processed ${eventCount} events`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log(`Error in Responses createStreamGenerator: ${message}`);
+      if (!message.includes("max_output_tokens")) {
+        vscode.window.showErrorMessage(
+          `Error during OpenAI Responses stream processing: ${message}`,
+        );
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Converts chat.md messages into Responses API input items.
+   *
+   * Reasoning items have to precede the assistant message they belong to, which is
+   * automatic here because cleanup moves thinking to the front of the content.
+   */
+  private convertToResponsesInput(
+    messages: readonly MessageParam[],
+    document?: vscode.TextDocument,
+  ): any[] {
+    const input: any[] = [];
+
+    for (const message of messages) {
+      if (message.role === "assistant") {
+        const textParts: any[] = [];
+
+        for (const block of message.content) {
+          if (block.type === "thinking") {
+            const payload = block.payload;
+            if (
+              payload?.kind === "openai_encrypted" &&
+              payload.itemId &&
+              payload.encryptedContent
+            ) {
+              input.push({
+                id: payload.itemId,
+                type: "reasoning",
+                summary: [],
+                encrypted_content: payload.encryptedContent,
+              });
+            }
+            // Raw reasoning text has nothing replayable in this API
+            continue;
+          }
+
+          if (block.type === "text" && block.value.trim() !== "") {
+            textParts.push({
+              type: "output_text",
+              text: block.value,
+              annotations: [],
+            });
+          } else if (block.type === "image") {
+            textParts.push({
+              type: "output_text",
+              text: "[Assistant Image]",
+              annotations: [],
+            });
+          }
+        }
+
+        if (textParts.length > 0) {
+          input.push({
+            role: "assistant",
+            content: textParts,
+          });
+        }
+        continue;
+      }
+
+      const userParts: any[] = [];
+      for (const block of message.content) {
+        if (block.type === "text") {
+          if (block.value.trim() !== "") {
+            userParts.push({ type: "input_text", text: block.value });
+          }
+        } else if (block.type === "image") {
+          const imageUrl = this.buildImageDataUrl(block, document);
+          if (imageUrl) {
+            userParts.push({ type: "input_image", image_url: imageUrl });
+          } else {
+            userParts.push({
+              type: "input_text",
+              text: `[Failed to load image: ${block.path}]`,
+            });
+          }
+        }
+      }
+
+      if (userParts.length > 0) {
+        input.push({ role: "user", content: userParts });
+      }
+    }
+
+    return input;
+  }
+
+  private buildImageDataUrl(
+    content: Content & { type: "image" },
+    document?: vscode.TextDocument,
+  ): string | undefined {
+    try {
+      const imagePath = document
+        ? resolveFilePath(content.path, document)
+        : content.path;
+      const imageData = readFileAsBuffer(imagePath);
+      if (!imageData) {
+        return undefined;
+      }
+      return `data:${this.getMimeType(imagePath)};base64,${imageData.toString("base64")}`;
+    } catch (error) {
+      log(`Error processing image ${content.path}: ${error}`);
+      return undefined;
+    }
+  }
+
+  private getMimeType(filePath: string): string {
+    const ext = path.extname(filePath).toLowerCase();
+    switch (ext) {
+      case ".png":
+        return "image/png";
+      case ".jpg":
+      case ".jpeg":
+        return "image/jpeg";
+      case ".gif":
+        return "image/gif";
+      case ".webp":
+        return "image/webp";
+      default:
+        return "application/octet-stream";
+    }
+  }
+}

--- a/src/openaiResponsesClient.ts
+++ b/src/openaiResponsesClient.ts
@@ -20,6 +20,7 @@ import { cleanMessagesForApi } from "./utils/messageCleanup";
  * reasoning context on gpt-* and o-series models.
  */
 export class OpenAIResponsesClient {
+  public lastUsage: Record<string, unknown> | undefined;
   private readonly apiUrl: string;
 
   constructor(
@@ -52,6 +53,7 @@ export class OpenAIResponsesClient {
     configName?: string,
     fileConfig?: Record<string, any>,
   ): AsyncGenerator<string[], void, unknown> {
+    this.lastUsage = undefined;
     log(`Starting OpenAI Responses request with ${messages.length} messages`);
 
     try {
@@ -227,6 +229,14 @@ export class OpenAIResponsesClient {
           }
 
           eventCount++;
+          if (data.response?.usage || data.usage) {
+            const usage = data.response?.usage || data.usage;
+            this.lastUsage = {
+              inputTokens: usage.input_tokens,
+              outputTokens: usage.output_tokens,
+              cacheReadTokens: usage.input_tokens_details?.cached_tokens,
+            };
+          }
 
           switch (data.type) {
             case "response.output_text.delta": {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,6 +1,7 @@
-import { MessageParam, Content, Role } from "./types";
+import { MessageParam, Content, Role, ThinkingContent } from "./types";
 import { log } from "./extension";
 import * as vscode from "vscode"; // Ensure vscode is imported
+import * as path from "path";
 import {
   isImageFile,
   resolveFilePath,
@@ -8,6 +9,11 @@ import {
   fileExists,
   readFileAsText, // Keep readFileAsText as it's used in parseUserContent
 } from "./utils/fileUtils";
+import {
+  splitAssistantSections,
+  parseThinkingSection,
+} from "./utils/thinkingBlocks";
+import { getThinkingEntry } from "./utils/thinkingMap";
 // import * as vscode from "vscode"; // Already imported
 
 /**
@@ -162,7 +168,7 @@ export function parseDocument(
     // selectedConfig and the three token/reasoning parameters are allowed in per-file configuration
     // The four keys (type, apiKey, base_url, model_name) should come from the named config in global settings
     // apiConfigs should also NOT be inline - it belongs in global settings only
-    const allowedKeys = new Set(["selectedConfig", "reasoningEffort", "maxTokens", "maxThinkingTokens"]);
+    const allowedKeys = new Set(["selectedConfig", "reasoningEffort", "maxTokens", "maxThinkingTokens", "openaiApi"]);
     const explicitlyForbiddenKeys = new Set(["type", "apiKey", "base_url", "model_name", "apiConfigs"]);
     
     const lines = preamble.split(/\r?\n/);
@@ -304,10 +310,15 @@ export function parseDocument(
     else if (role === "assistant") {
        // Only add assistant message if it has actual content
        if (content) {
-         messages.push({
-           role: "assistant",
-           content: [{ type: "text", value: content }], // Assistant content is treated as plain text for now
-         });
+         const assistantContent = parseAssistantContent(content, document);
+         if (assistantContent.length > 0) {
+           messages.push({
+             role: "assistant",
+             content: assistantContent,
+           });
+         } else {
+           log("Skipping assistant block that parsed to empty content.");
+         }
        } else {
          log("Skipping empty assistant block (non-triggering).");
        }
@@ -332,6 +343,62 @@ export function parseDocument(
   });
 }
 
+
+/**
+ * Parses the content of an assistant block into content blocks.
+ *
+ * A block without any "## %%" marker is plain text, which keeps the original format
+ * working. When markers are present, thinking sections become thinking content and
+ * their trailing "qualified_model_name::hash8" line is resolved against
+ * cmdassets/thinking_map.json.
+ */
+export function parseAssistantContent(
+  content: string,
+  document?: vscode.TextDocument,
+): Content[] {
+  const sections = splitAssistantSections(content);
+  const docDir = document ? path.dirname(document.uri.fsPath) : undefined;
+  const result: Content[] = [];
+
+  for (const section of sections) {
+    if (section.type === "text") {
+      const text = section.content.trim();
+      if (text) {
+        result.push({ type: "text", value: text });
+      }
+      continue;
+    }
+
+    const parsed = parseThinkingSection(section.content);
+    if (!parsed.text && !parsed.hash) {
+      // Empty thinking section, nothing to carry over
+      continue;
+    }
+
+    const thinking: ThinkingContent = {
+      type: "thinking",
+      value: parsed.text,
+      model: parsed.model,
+      hash: parsed.hash,
+    };
+
+    if (parsed.hash && docDir) {
+      const entry = getThinkingEntry(docDir, parsed.hash);
+      if (entry) {
+        const { model: _entryModel, createdAt: _createdAt, ...payload } = entry;
+        thinking.payload = payload;
+      } else {
+        log(
+          `No thinking_map entry for hash ${parsed.hash}, treating thinking as display only`,
+        );
+      }
+    }
+
+    result.push(thinking);
+  }
+
+  return result;
+}
 
 /**
  * Checks if the given text content contains any image references (markdown or attached file syntax).

--- a/src/prompts/promptExecutor.ts
+++ b/src/prompts/promptExecutor.ts
@@ -2,7 +2,12 @@ import * as vscode from "vscode";
 import * as path from "path";
 import { log } from "../extension";
 import { mcpClientManager } from "../extension";
-import { ensureDirectoryExists, writeFile } from "../utils/fileUtils";
+import {
+  ensureDirectoryExists,
+  getAssetsDirectory,
+  getAssetsRelativePath,
+  writeFile,
+} from "../utils/fileUtils";
 import { formatPromptResult } from "../utils/mcpResultFormatter";
 
 /**
@@ -54,7 +59,7 @@ export async function insertPrompt(
       try {
         // Create cmdassets directory relative to the current document
         const docDir = path.dirname(editor.document.uri.fsPath);
-        const assetsDir = path.join(docDir, "cmdassets");
+        const assetsDir = getAssetsDirectory(docDir);
         ensureDirectoryExists(assetsDir);
 
         // Generate a unique filename with timestamp and random string
@@ -68,7 +73,7 @@ export async function insertPrompt(
         const promptName = promptId.split('.')[1];
         const sanitizedPromptName = promptName.replace(/[^a-zA-Z0-9-_]/g, "_");
         const filename = `mcp-prompt-${sanitizedPromptName}-${timestamp}-${randomString}.md`;
-        const relativeFilePath = path.join("cmdassets", filename);
+        const relativeFilePath = getAssetsRelativePath(docDir, filename);
         const fullFilePath = path.join(assetsDir, filename);
 
         // Add prompt metadata as a header comment in the file

--- a/src/streamer.ts
+++ b/src/streamer.ts
@@ -23,11 +23,21 @@ import { log, statusManager, requestStatusBarUpdate } from "./extension";
 import { generateToolCallingSystemPrompt, getAutoSaveAfterStreaming } from "./config";
 import { mcpClientManager } from "./mcpClientManager";
 import { appendToChatHistory } from "./utils/fileUtils";
-import { parseToolCall, checkForCompletedToolCall } from "./tools/toolCallParser";
+import {
+  parseToolCall,
+  checkForCompletedToolCall,
+  CMD_TOOL_CALL_OPEN_TAG,
+  CMD_TOOL_CALL_CLOSE_TAG,
+} from "./tools/toolCallParser";
 
-// Written with unicode escapes on purpose so that this literal is never mistaken
+// Written with unicode escapes on purpose so that these literals are never mistaken
 // for an actual tool call by chat.md's own parser.
-const TOOL_CALL_OPEN_TAG = "\u003ccmd:tool_call\u003e";
+const TOOL_CALL_OPEN_TAG = CMD_TOOL_CALL_OPEN_TAG;
+/** Any use of the qualified namespace, including a malformed one */
+const CMD_NAMESPACE_PREFIX = "\u003ccmd:";
+const CMD_TOOL_NAME_TAGS = "\u003ccmd:tool_name\u003e...\u003c/cmd:tool_name\u003e";
+const CMD_PARAM_TAGS =
+  "\u003ccmd:param name=\"...\"\u003e...\u003c/cmd:param\u003e";
 
 /**
  * Service for streaming LLM responses
@@ -576,6 +586,9 @@ export class StreamingService {
     // Capture the success state early to avoid race conditions with isActive flag
     let streamCompletedSuccessfully = false;
     let shouldAutoSaveOnCompletion = false;
+    // Set when a malformed tool call correction turn was appended, which already
+    // includes its own user and assistant blocks
+    let correctionInserted = false;
 
     try {
       log(
@@ -915,6 +928,24 @@ export class StreamingService {
             }
             await this.insertToolExecuteBlockAfterToolCalls(streamer);
             toolExecuteInserted = true;
+          } else if (
+            !bufferingMode &&
+            !updateFailed &&
+            !cancelledExternally &&
+            streamer.isActive &&
+            streamer.tokens.length > 0 &&
+            stripThinkingSections(streamer.tokens.join("")).includes(
+              CMD_NAMESPACE_PREFIX,
+            )
+          ) {
+            // The turn ended naturally without a single complete tool call, yet the
+            // assistant text mentions the cmd namespace: it tried to call a tool and
+            // got the format wrong. Append a correction user turn together with an
+            // empty assistant block, so the document change resumes streaming and the
+            // model can retry. Only reached on natural exit, never on cancellation or
+            // failure.
+            await this.appendMalformedToolCorrection(streamer);
+            correctionInserted = true;
           }
           
           // Capture success state immediately to avoid race conditions
@@ -1156,10 +1187,8 @@ export class StreamingService {
           // 1. The streaming finished naturally (not due to a tool call)
           // 2. Tokens were actually written successfully to the document (non-zero tokens)
           // 3. The streamer wasn't cancelled or failed due to other errors
-          const malformedCommand = !streamer.isHandlingToolCall &&
-            stripThinkingSections(streamer.tokens.join("")).includes("<cmd:");
-          if (malformedCommand) {
-            await this.appendMalformedToolCorrection(streamer);
+          if (correctionInserted) {
+            log('Not adding user block since a tool call correction turn was appended');
             userBlockAdded = true;
           } else if (!streamer.isHandlingToolCall && streamer.tokens.length > 0 && streamer.isActive) {
             log('Adding new user block after completed assistant response');
@@ -1294,17 +1323,56 @@ export class StreamingService {
     try {
       const text = this.document.getText();
       const blocks = findAllAssistantBlocks(text);
-      if (blocks.length === 0) return;
+      if (blocks.length === 0) {
+        log("No assistant blocks found, cannot add tool call correction");
+        return;
+      }
+
       const block = blocks[blocks.length - 1];
       const offset = block.contentStart + streamer.tokens.join("").length;
-      const correction = "\n\n# %% user\n" +
-        "The previous assistant response contained an invalid tool call. " +
-        "Use " + String.fromCharCode(60) + "cmd:tool_call" + String.fromCharCode(62) + ", " + String.fromCharCode(60) + "cmd:tool_name" + String.fromCharCode(62) + ", and " +
-        String.fromCharCode(60) + "cmd:param name=\"name\"" + String.fromCharCode(62) + "value" + String.fromCharCode(60) + "/cmd:param" + String.fromCharCode(62) +
-        " without triple-backtick fences.\n\n# %% assistant\n";
+
+      // Describe the format exactly as the parser accepts it: qualified tags, no
+      // fences, closing tag on its own line. Guidance a model could follow into
+      // another rejected call would just repeat this correction. Kept on a single
+      // line so the description itself can never match a real tool call.
+      const correction =
+        "\n\n# %% user\n" +
+        "That response used the " +
+        CMD_NAMESPACE_PREFIX +
+        " namespace but contained no valid tool call. Retry with the exact format: " +
+        CMD_TOOL_CALL_OPEN_TAG +
+        " on its own line, then " +
+        CMD_TOOL_NAME_TAGS +
+        ", then one " +
+        CMD_PARAM_TAGS +
+        " per parameter, then " +
+        CMD_TOOL_CALL_CLOSE_TAG +
+        " on its own line. No triple-backtick fences.\n\n# %% assistant\n";
+
       const edit = new vscode.WorkspaceEdit();
       edit.insert(this.document.uri, this.document.positionAt(offset), correction);
-      await vscode.workspace.applyEdit(edit);
+      const applied = await vscode.workspace.applyEdit(edit);
+
+      if (!applied) {
+        log("Failed to append tool call correction turn");
+        return;
+      }
+
+      log("Appended tool call correction turn, streaming will resume");
+      requestStatusBarUpdate(this.document.uri.fsPath, "streaming finished");
+
+      // The new empty assistant block restarts streaming from the document change,
+      // so this streamer is done
+      streamer.isActive = false;
+
+      try {
+        if (getAutoSaveAfterStreaming()) {
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          await this.document.save();
+        }
+      } catch (error) {
+        log(`Error during auto-save after tool call correction: ${error}`);
+      }
     } finally {
       this.lock.release();
     }

--- a/src/streamer.ts
+++ b/src/streamer.ts
@@ -1363,6 +1363,13 @@ export class StreamingService {
         CMD_TOOL_CALL_CLOSE_TAG +
         " on its own line. No triple-backtick fences.\n\n# %% assistant\n";
 
+      // This streamer has to be marked done BEFORE the edit is applied. The edit
+      // fires a document change whose handler calls startStreaming, and that has a
+      // pre-lock guard which returns immediately if any streamer is still active
+      // instead of queueing on the lock. Marking it afterwards means the retry turn
+      // is silently never started.
+      streamer.isActive = false;
+
       const edit = new vscode.WorkspaceEdit();
       edit.insert(this.document.uri, this.document.positionAt(offset), correction);
       const applied = await vscode.workspace.applyEdit(edit);
@@ -1374,10 +1381,6 @@ export class StreamingService {
 
       log("Appended tool call correction turn, streaming will resume");
       requestStatusBarUpdate(this.document.uri.fsPath, "streaming finished");
-
-      // The new empty assistant block restarts streaming from the document change,
-      // so this streamer is done
-      streamer.isActive = false;
 
       try {
         if (getAutoSaveAfterStreaming()) {

--- a/src/streamer.ts
+++ b/src/streamer.ts
@@ -22,7 +22,10 @@ import {
 import { log, statusManager, requestStatusBarUpdate } from "./extension";
 import { generateToolCallingSystemPrompt, getAutoSaveAfterStreaming } from "./config";
 import { mcpClientManager } from "./mcpClientManager";
-import { appendToChatHistory } from "./utils/fileUtils";
+import {
+  appendToChatHistory,
+  updateChatHistoryUsage,
+} from "./utils/fileUtils";
 import {
   parseToolCall,
   checkForCompletedToolCall,
@@ -566,6 +569,16 @@ export class StreamingService {
     );
   }
 
+  public getLastUsage(): Record<string, unknown> | undefined {
+    if (this.provider === "anthropic") {
+      return this.anthropicClient?.lastUsage;
+    }
+    if (this.openaiResponsesClient?.lastUsage) {
+      return this.openaiResponsesClient.lastUsage;
+    }
+    return this.openaiClient?.lastUsage;
+  }
+
   public async streamResponse(
     messages: readonly MessageParam[],
     streamer: StreamerState,
@@ -907,6 +920,7 @@ export class StreamingService {
             }
           }
 
+          updateChatHistoryUsage(streamer.historyFilePath || "", this.getLastUsage());
           log(
             `Stream completed successfully, processed ${tokenCount} tokens total, provider: ${this.provider}${bufferingMode ? " (buffered tool calls)" : ""}`,
           );

--- a/src/streamer.ts
+++ b/src/streamer.ts
@@ -1,9 +1,23 @@
 import * as vscode from "vscode";
+import * as path from "path";
 import { MessageParam, StreamerState } from "./types";
 import { Lock } from "./utils/lock";
 import { AnthropicClient } from "./anthropicClient";
 import { OpenAIClient } from "./openaiClient";
-import { findAssistantBlocks, findAllAssistantBlocks } from "./parser";
+import { OpenAIResponsesClient } from "./openaiResponsesClient";
+import {
+  decodeThinkingPayloadToken,
+  formatSignatureLine,
+  isThinkingPayloadToken,
+  isThinkingToken,
+  renderStreamTokens,
+} from "./utils/thinkingBlocks";
+import { putThinkingEntry } from "./utils/thinkingMap";
+import {
+  findAssistantBlocks,
+  findAllAssistantBlocks,
+  parseAssistantContent,
+} from "./parser";
 import { log, statusManager, requestStatusBarUpdate } from "./extension";
 import { generateToolCallingSystemPrompt, getAutoSaveAfterStreaming } from "./config";
 import { mcpClientManager } from "./mcpClientManager";
@@ -20,6 +34,9 @@ const TOOL_CALL_OPEN_TAG = "\u003ctool_call\u003e";
 export class StreamingService {
   private readonly anthropicClient?: AnthropicClient;
   private readonly openaiClient?: OpenAIClient;
+  private openaiResponsesClient?: OpenAIResponsesClient;
+  private readonly openaiApiKey?: string;
+  private readonly openaiBaseUrl?: string;
   private readonly provider: string;
 
   constructor(
@@ -71,7 +88,11 @@ export class StreamingService {
       if (this.provider === "anthropic") {
         this.anthropicClient = new AnthropicClient(apiKey);
       } else if (this.provider === "openai") {
+        this.openaiBaseUrl = baseUrl;
         this.openaiClient = new OpenAIClient(apiKey, baseUrl);
+        // The Responses API client is created lazily, since the choice depends on
+        // per-file configuration that is only known per request.
+        this.openaiApiKey = apiKey;
       } else {
         log(`Unknown provider: ${this.provider}, falling back to Anthropic`);
         this.provider = "anthropic";
@@ -247,6 +268,7 @@ export class StreamingService {
     return (
       message.includes("max_tokens") ||
       message.includes("max_completion_tokens") ||
+      message.includes("max_output_tokens") ||
       message.includes("token limit") ||
       message.includes("context length") ||
       message.includes("finish_reason=length")
@@ -261,6 +283,61 @@ export class StreamingService {
   private checkForCompletedToolCall(text: string) {
     // Use the imported checkForCompletedToolCall function directly
     return checkForCompletedToolCall(text);
+  }
+
+  /**
+   * Stores a reasoning payload in cmdassets/thinking_map.json and returns the
+   * "qualified_model_name::hash8" line that references it.
+   */
+  private recordThinkingPayload(token: string): string | undefined {
+    const decoded = decodeThinkingPayloadToken(token);
+    if (!decoded || typeof decoded !== "object") {
+      log("Ignoring malformed thinking payload token");
+      return undefined;
+    }
+
+    const { model, ...payload } = decoded as any;
+    if (!model || !payload.kind) {
+      log("Ignoring thinking payload without model or kind");
+      return undefined;
+    }
+
+    try {
+      const docDir = path.dirname(this.document.uri.fsPath);
+      const hash = putThinkingEntry(docDir, model, payload);
+      log(`Stored ${payload.kind} thinking payload as ${model}::${hash}`);
+      return formatSignatureLine(model, hash);
+    } catch (error) {
+      log(`Failed to store thinking payload: ${error}`);
+      return undefined;
+    }
+  }
+
+  /**
+   * Turns a batch of stream tokens into the text to append to the assistant block,
+   * inserting "## %% thinking" / "## %% text" markers as the token kind changes.
+   */
+  private renderTokens(streamer: StreamerState, tokens: string[]): string[] {
+    const state = {
+      thinkingOpen: streamer.thinkingOpen ?? false,
+      textOpen: streamer.textOpen ?? false,
+      sawThinking: streamer.sawThinking ?? false,
+      scanOffset: streamer.scanOffset ?? 0,
+    };
+
+    const rendered = renderStreamTokens(
+      tokens,
+      streamer.tokens.join(""),
+      state,
+      (token) => this.recordThinkingPayload(token),
+    );
+
+    streamer.thinkingOpen = state.thinkingOpen;
+    streamer.textOpen = state.textOpen;
+    streamer.sawThinking = state.sawThinking;
+    streamer.scanOffset = state.scanOffset;
+
+    return rendered.length > 0 ? [rendered] : [];
   }
 
   /**
@@ -578,14 +655,50 @@ export class StreamingService {
               fileConfig,
             );
           } else if (this.provider === "openai" && this.openaiClient) {
-            stream = await this.openaiClient.streamCompletion(
-              messages,
-              this.document,
-              systemPrompt,
-              modelNameOverride,
+            // gpt-* and o-series models on OpenAI itself go through the Responses
+            // API, which is the only way to keep encrypted reasoning across turns
+            const { resolveOpenaiApiStyle } = require("./config");
+            let modelForRouting = modelNameOverride;
+            if (!modelForRouting) {
+              try {
+                modelForRouting = getModelName();
+              } catch {
+                modelForRouting = undefined;
+              }
+            }
+            const apiStyle = resolveOpenaiApiStyle(
+              modelForRouting,
+              this.openaiBaseUrl,
               this.configNameOverride,
               fileConfig,
             );
+            log(`Using OpenAI API style: ${apiStyle}`);
+
+            if (apiStyle === "responses") {
+              if (!this.openaiResponsesClient) {
+                this.openaiResponsesClient = new OpenAIResponsesClient(
+                  this.openaiApiKey ?? "",
+                  this.openaiBaseUrl,
+                );
+              }
+              stream = await this.openaiResponsesClient.streamCompletion(
+                messages,
+                this.document,
+                systemPrompt,
+                modelNameOverride,
+                this.configNameOverride,
+                fileConfig,
+              );
+            } else {
+              stream = await this.openaiClient.streamCompletion(
+                messages,
+                this.document,
+                systemPrompt,
+                modelNameOverride,
+                this.configNameOverride,
+                fileConfig,
+              );
+            }
           } else {
             throw new Error(
               `Provider ${this.provider} not properly configured`,
@@ -652,7 +765,17 @@ export class StreamingService {
               if (bufferingMode) {
                 // A tool call has already completed in this turn: buffer what follows
                 // and keep popping further tool calls off the left of the buffer.
-                bufferText += tokens.join("");
+                const textTokens = tokens.filter(
+                  (token) =>
+                    !isThinkingToken(token) && !isThinkingPayloadToken(token),
+                );
+                if (textTokens.length !== tokens.length) {
+                  log("Ignoring thinking tokens received while buffering tool calls");
+                }
+                if (textTokens.length === 0) {
+                  continue;
+                }
+                bufferText += textTokens.join("");
                 const bufferResult = await this.processBufferedToolCalls(
                   streamer,
                   bufferText,
@@ -665,10 +788,19 @@ export class StreamingService {
                 continue;
               }
 
-              // Check if adding these tokens would complete a tool call
-              const currentTokens = [...streamer.tokens, ...tokens].join("");
-              const toolCallResult =
-                this.checkForCompletedToolCall(currentTokens);
+              // Turn thinking/text tokens into document text with section markers
+              const renderedTokens = this.renderTokens(streamer, tokens);
+              if (renderedTokens.length === 0) {
+                continue;
+              }
+
+              // Check if adding these tokens would complete a tool call. Only the
+              // current text section is scanned, never thinking content.
+              const currentTokens = [...streamer.tokens, ...renderedTokens].join("");
+              const scanStart = streamer.scanOffset ?? 0;
+              const toolCallResult = this.checkForCompletedToolCall(
+                currentTokens.substring(scanStart),
+              );
 
               // Check if we have a completed tool call
               if (toolCallResult && toolCallResult.isComplete) {
@@ -682,8 +814,9 @@ export class StreamingService {
                 streamer.isHandlingToolCall = true;
 
                 try {
-                  // Get the end index of the completed tool call
-                  const { endIndex } = toolCallResult;
+                  // Get the end index of the completed tool call (absolute, since
+                  // detection ran on the current text section only)
+                  const endIndex = scanStart + toolCallResult.endIndex;
                   const toolName = 'toolName' in toolCallResult ? toolCallResult.toolName : '';
                   
                   // Always show the status bar when a tool call is detected
@@ -711,7 +844,7 @@ export class StreamingService {
                   const truncatedNewTokens: string[] = [];
                   let currentLength = 0;
 
-                  for (const token of tokens) {
+                  for (const token of renderedTokens) {
                     if (currentLength >= keepLength) {
                       break; // Stop adding tokens if we've reached the end of the tool call
                     }
@@ -734,7 +867,7 @@ export class StreamingService {
                   }
 
                   log(
-                    `Truncated tokens from ${tokens.length} to ${truncatedNewTokens.length} to exclude content after </tool_call>`,
+                    `Truncated tokens from ${renderedTokens.length} to ${truncatedNewTokens.length} to exclude content after </tool_call>`,
                   );
 
                   // Update the document with truncated tokens
@@ -781,7 +914,7 @@ export class StreamingService {
                 try {
                   const updateSuccess = await this.updateDocumentWithTokens(
                     streamer,
-                    tokens,
+                    renderedTokens,
                   );
                   if (!updateSuccess) {
                     log("Token update failed, canceling streaming entirely");
@@ -966,39 +1099,32 @@ export class StreamingService {
                 `Adding partial assistant response to context: ${partialResponse.substring(0, 100)}${partialResponse.length > 100 ? "..." : ""}`,
               );
 
+              // Parse the partial response so thinking sections become thinking
+              // blocks instead of leaking their "## %%" markers into the API
+              const partialContent = parseAssistantContent(
+                partialResponse,
+                this.document,
+              );
+
               // Check if the last message is from the assistant (it should be a continuation)
               if (
                 updatedMessages.length > 0 &&
                 updatedMessages[updatedMessages.length - 1].role === "assistant"
               ) {
                 log("Last message is from assistant, appending to it");
-
-                // Create a new text content item for the existing partial response
-                const existingContent =
-                  updatedMessages[updatedMessages.length - 1].content;
-                const existingText = existingContent
-                  .filter((c) => c.type === "text")
-                  .map((c) => (c as any).value)
-                  .join("\n\n");
-
-                // Create a new content array with the combined text
-                const newContent: import("./types").MessageParam["content"] = existingContent.filter(
-                  (c) => c.type !== "text",
-                );
-                newContent.push({
-                  type: "text",
-                  value: existingText + partialResponse,
-                });
-
-                // Replace the content in the last message
-                updatedMessages[updatedMessages.length - 1].content =
-                  newContent;
+                updatedMessages[updatedMessages.length - 1] = {
+                  role: "assistant",
+                  content: [
+                    ...updatedMessages[updatedMessages.length - 1].content,
+                    ...partialContent,
+                  ],
+                };
               } else {
                 // Add a new assistant message with the partial response
                 log("Adding new assistant message with partial response");
                 updatedMessages.push({
                   role: "assistant",
-                  content: [{ type: "text", value: partialResponse }],
+                  content: partialContent,
                 });
               }
 

--- a/src/streamer.ts
+++ b/src/streamer.ts
@@ -6,6 +6,7 @@ import { AnthropicClient } from "./anthropicClient";
 import { OpenAIClient } from "./openaiClient";
 import { OpenAIResponsesClient } from "./openaiResponsesClient";
 import {
+  stripThinkingSections,
   decodeThinkingPayloadToken,
   formatSignatureLine,
   isThinkingPayloadToken,
@@ -26,7 +27,7 @@ import { parseToolCall, checkForCompletedToolCall } from "./tools/toolCallParser
 
 // Written with unicode escapes on purpose so that this literal is never mistaken
 // for an actual tool call by chat.md's own parser.
-const TOOL_CALL_OPEN_TAG = "\u003ctool_call\u003e";
+const TOOL_CALL_OPEN_TAG = "\u003ccmd:tool_call\u003e";
 
 /**
  * Service for streaming LLM responses
@@ -351,57 +352,11 @@ export class StreamingService {
    */
   private classifyBuffer(
     buffer: string,
-  ): "tool_call" | "closing_fence" | "incomplete" | "invalid" {
-    const trimmed = buffer.replace(/^\s+/, "");
-
-    // Only whitespace so far - wait for more tokens
-    if (trimmed.length === 0) {
-      return "incomplete";
-    }
-
-    // Non fenced tool call, or a partial prefix of its opening tag
-    if (trimmed.startsWith(TOOL_CALL_OPEN_TAG)) {
-      return "tool_call";
-    }
-    if (TOOL_CALL_OPEN_TAG.startsWith(trimmed)) {
-      return "incomplete";
-    }
-
-    if (trimmed.startsWith("```")) {
-      const afterFence = trimmed.substring(3);
-      const fenceLineMatch =
-        /^([a-zA-Z0-9_\-]*)(?:[ \t]*\r?\n|[ \t]+)([\s\S]*)$/.exec(afterFence);
-
-      // Still receiving the fence line itself (e.g. "```too")
-      if (!fenceLineMatch) {
-        return "incomplete";
-      }
-
-      const annotation = fenceLineMatch[1];
-      const afterFenceLine = fenceLineMatch[2].replace(/^\s+/, "");
-
-      if (afterFenceLine.startsWith(TOOL_CALL_OPEN_TAG)) {
-        return "tool_call";
-      }
-      if (
-        afterFenceLine.length === 0 ||
-        TOOL_CALL_OPEN_TAG.startsWith(afterFenceLine)
-      ) {
-        return "incomplete";
-      }
-      // A bare "```" line that isn't opening a tool call is the closing fence of
-      // the tool call that was just emitted (detected while partially fenced).
-      if (annotation.length === 0) {
-        return "closing_fence";
-      }
-      return "invalid";
-    }
-
-    // Partial fence, e.g. "`" or "``"
-    if ("```".startsWith(trimmed)) {
-      return "incomplete";
-    }
-
+  ): "tool_call" | "incomplete" | "invalid" {
+    const value = buffer.replace(/^\s+/, "");
+    if (!value) return "incomplete";
+    if (value.startsWith(TOOL_CALL_OPEN_TAG)) return "tool_call";
+    if (TOOL_CALL_OPEN_TAG.startsWith(value)) return "incomplete";
     return "invalid";
   }
 
@@ -840,7 +795,7 @@ export class StreamingService {
                   const existingLength = streamer.tokens.join("").length;
                   const keepLength = Math.max(0, endIndex - existingLength);
 
-                  // Create a new array of tokens that only includes content up to the </tool_call> tag
+                  // Create a new array of tokens that only includes content up to the </cmd:tool_call> tag
                   const truncatedNewTokens: string[] = [];
                   let currentLength = 0;
 
@@ -867,7 +822,7 @@ export class StreamingService {
                   }
 
                   log(
-                    `Truncated tokens from ${renderedTokens.length} to ${truncatedNewTokens.length} to exclude content after </tool_call>`,
+                    `Truncated tokens from ${renderedTokens.length} to ${truncatedNewTokens.length} to exclude content after </cmd:tool_call>`,
                   );
 
                   // Update the document with truncated tokens
@@ -1201,7 +1156,12 @@ export class StreamingService {
           // 1. The streaming finished naturally (not due to a tool call)
           // 2. Tokens were actually written successfully to the document (non-zero tokens)
           // 3. The streamer wasn't cancelled or failed due to other errors
-          if (!streamer.isHandlingToolCall && streamer.tokens.length > 0 && streamer.isActive) {
+          const malformedCommand = !streamer.isHandlingToolCall &&
+            stripThinkingSections(streamer.tokens.join("")).includes("<cmd:");
+          if (malformedCommand) {
+            await this.appendMalformedToolCorrection(streamer);
+            userBlockAdded = true;
+          } else if (!streamer.isHandlingToolCall && streamer.tokens.length > 0 && streamer.isActive) {
             log('Adding new user block after completed assistant response');
             await this.appendNewUserBlock(streamer);
             userBlockAdded = true;
@@ -1327,6 +1287,29 @@ export class StreamingService {
   /**
    * Appends a new user block after the assistant response has completed
    */
+  private async appendMalformedToolCorrection(
+    streamer: StreamerState,
+  ): Promise<void> {
+    await this.lock.acquire();
+    try {
+      const text = this.document.getText();
+      const blocks = findAllAssistantBlocks(text);
+      if (blocks.length === 0) return;
+      const block = blocks[blocks.length - 1];
+      const offset = block.contentStart + streamer.tokens.join("").length;
+      const correction = "\n\n# %% user\n" +
+        "The previous assistant response contained an invalid tool call. " +
+        "Use " + String.fromCharCode(60) + "cmd:tool_call" + String.fromCharCode(62) + ", " + String.fromCharCode(60) + "cmd:tool_name" + String.fromCharCode(62) + ", and " +
+        String.fromCharCode(60) + "cmd:param name=\"name\"" + String.fromCharCode(62) + "value" + String.fromCharCode(60) + "/cmd:param" + String.fromCharCode(62) +
+        " without triple-backtick fences.\n\n# %% assistant\n";
+      const edit = new vscode.WorkspaceEdit();
+      edit.insert(this.document.uri, this.document.positionAt(offset), correction);
+      await vscode.workspace.applyEdit(edit);
+    } finally {
+      this.lock.release();
+    }
+  }
+
   private async appendNewUserBlock(streamer: StreamerState): Promise<void> {
     await this.lock.acquire();
     

--- a/src/streamer.ts
+++ b/src/streamer.ts
@@ -10,6 +10,10 @@ import { mcpClientManager } from "./mcpClientManager";
 import { appendToChatHistory } from "./utils/fileUtils";
 import { parseToolCall, checkForCompletedToolCall } from "./tools/toolCallParser";
 
+// Written with unicode escapes on purpose so that this literal is never mistaken
+// for an actual tool call by chat.md's own parser.
+const TOOL_CALL_OPEN_TAG = "\u003ctool_call\u003e";
+
 /**
  * Service for streaming LLM responses
  */
@@ -260,6 +264,244 @@ export class StreamingService {
   }
 
   /**
+   * Classify buffered text that follows an already emitted tool call.
+   *
+   * - "tool_call": the buffer starts with a valid tool call prefix (fenced or not)
+   * - "closing_fence": the buffer starts with the dangling closing fence of the
+   *   previously emitted (partially fenced) tool call
+   * - "incomplete": the buffer could still become one of the above, wait for tokens
+   * - "invalid": the buffer is normal assistant text, so the stream must stop
+   */
+  private classifyBuffer(
+    buffer: string,
+  ): "tool_call" | "closing_fence" | "incomplete" | "invalid" {
+    const trimmed = buffer.replace(/^\s+/, "");
+
+    // Only whitespace so far - wait for more tokens
+    if (trimmed.length === 0) {
+      return "incomplete";
+    }
+
+    // Non fenced tool call, or a partial prefix of its opening tag
+    if (trimmed.startsWith(TOOL_CALL_OPEN_TAG)) {
+      return "tool_call";
+    }
+    if (TOOL_CALL_OPEN_TAG.startsWith(trimmed)) {
+      return "incomplete";
+    }
+
+    if (trimmed.startsWith("```")) {
+      const afterFence = trimmed.substring(3);
+      const fenceLineMatch =
+        /^([a-zA-Z0-9_\-]*)(?:[ \t]*\r?\n|[ \t]+)([\s\S]*)$/.exec(afterFence);
+
+      // Still receiving the fence line itself (e.g. "```too")
+      if (!fenceLineMatch) {
+        return "incomplete";
+      }
+
+      const annotation = fenceLineMatch[1];
+      const afterFenceLine = fenceLineMatch[2].replace(/^\s+/, "");
+
+      if (afterFenceLine.startsWith(TOOL_CALL_OPEN_TAG)) {
+        return "tool_call";
+      }
+      if (
+        afterFenceLine.length === 0 ||
+        TOOL_CALL_OPEN_TAG.startsWith(afterFenceLine)
+      ) {
+        return "incomplete";
+      }
+      // A bare "```" line that isn't opening a tool call is the closing fence of
+      // the tool call that was just emitted (detected while partially fenced).
+      if (annotation.length === 0) {
+        return "closing_fence";
+      }
+      return "invalid";
+    }
+
+    // Partial fence, e.g. "`" or "``"
+    if ("```".startsWith(trimmed)) {
+      return "incomplete";
+    }
+
+    return "invalid";
+  }
+
+  /**
+   * Process buffered text that follows an already emitted tool call.
+   * Pops complete tool calls off the left of the buffer, emitting each one into the
+   * assistant block without executing anything. Stops streaming as soon as the
+   * buffer no longer looks like another tool call.
+   *
+   * @returns the unconsumed buffer, whether streaming should stop, and whether it
+   *          stopped because a document update failed
+   */
+  private async processBufferedToolCalls(
+    streamer: StreamerState,
+    bufferText: string,
+  ): Promise<{ remainingBuffer: string; stop: boolean; failed: boolean }> {
+    let buffer = bufferText;
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const classification = this.classifyBuffer(buffer);
+
+      if (classification === "incomplete") {
+        // Could still become another tool call - wait for more tokens
+        return { remainingBuffer: buffer, stop: false, failed: false };
+      }
+
+      if (classification === "invalid") {
+        log(
+          `Buffered content is not another tool call, interrupting stream and discarding buffer: "${buffer.substring(0, 80)}${buffer.length > 80 ? "..." : ""}"`,
+        );
+        return { remainingBuffer: "", stop: true, failed: false };
+      }
+
+      if (classification === "closing_fence") {
+        const fenceMatch = /^\s*```[ \t]*\r?\n/.exec(buffer);
+        if (!fenceMatch) {
+          return { remainingBuffer: buffer, stop: false, failed: false };
+        }
+        log("Emitting dangling closing fence of the previous tool call");
+        const fenceUpdated = await this.updateDocumentWithTokens(streamer, [
+          fenceMatch[0],
+        ]);
+        if (!fenceUpdated) {
+          log("Token update failed when emitting closing fence, canceling");
+          streamer.isActive = false;
+          return { remainingBuffer: "", stop: true, failed: true };
+        }
+        buffer = buffer.substring(fenceMatch[0].length);
+        continue;
+      }
+
+      // classification === "tool_call"
+      const toolCallResult = this.checkForCompletedToolCall(buffer);
+      if (!toolCallResult || !toolCallResult.isComplete) {
+        // Tool call is still streaming in - wait for more tokens
+        return { remainingBuffer: buffer, stop: false, failed: false };
+      }
+
+      const toolCallText = buffer.substring(0, toolCallResult.endIndex);
+      log(
+        `Emitting additional parallel tool call (${toolCallText.length} chars) without executing it`,
+      );
+      const updateSuccess = await this.updateDocumentWithTokens(streamer, [
+        toolCallText,
+      ]);
+      if (!updateSuccess) {
+        log("Token update failed when emitting buffered tool call, canceling");
+        streamer.isActive = false;
+        return { remainingBuffer: "", stop: true, failed: true };
+      }
+
+      buffer = buffer.substring(toolCallResult.endIndex);
+    }
+  }
+
+  /**
+   * Insert a single tool_execute block after the tool calls written into the
+   * assistant block. The document listener executes the tool calls one at a time,
+   * adding a further tool_execute block after each result until all of them ran.
+   */
+  private async insertToolExecuteBlockAfterToolCalls(
+    streamer: StreamerState,
+  ): Promise<void> {
+    const text = this.document.getText();
+    const blockStart = this.findBlockStartPosition(text, streamer);
+
+    if (blockStart === -1) {
+      log("Could not find position to insert tool_execute block");
+      return;
+    }
+
+    const currentText = streamer.tokens.join("");
+    const insertPosition = this.document.positionAt(
+      blockStart + currentText.length,
+    );
+
+    // Check for unbalanced fence blocks: an opening ``` with no matching closing ```
+    const openingFenceMatch =
+      /```(?:[a-zA-Z0-9_\-]*)?(?:\s*\n|\s+)\s*[<]tool_call[>][\s\S]*?\n\s*<\/tool_call>(?!\s*\n\s*```)/s.exec(
+        currentText,
+      );
+
+    let textToInsert = "";
+
+    if (openingFenceMatch) {
+      log(
+        "Detected unbalanced fence block - adding closing fence before tool_execute block",
+      );
+      textToInsert = "\n```\n\n# %% tool_execute\n";
+    } else {
+      textToInsert = "\n\n# %% tool_execute\n";
+    }
+
+    const edit = new vscode.WorkspaceEdit();
+    edit.insert(this.document.uri, insertPosition, textToInsert);
+    const applied = await vscode.workspace.applyEdit(edit);
+
+    if (applied) {
+      log(
+        `Successfully inserted ${openingFenceMatch ? "closing fence and " : ""}tool_execute block`,
+      );
+
+      // The tool_execute block has been added, but the status must stay visible
+      // until the DocumentListener picks up the change and executes the tool
+      requestStatusBarUpdate(
+        this.document.uri.fsPath,
+        "tool auto-execution started",
+      );
+
+      // Mark streamer as inactive BEFORE auto-save to prevent conflicts
+      streamer.isActive = false;
+      log("Marked streamer as inactive after tool_execute block insertion");
+
+      // Small delay to ensure state propagation before auto-save document changes
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Auto-save after tool_execute block generation if enabled
+      try {
+        if (getAutoSaveAfterStreaming()) {
+          log("Auto-saving document after tool_execute block generation");
+
+          // Brief delay to ensure the insertion is processed by VS Code
+          await new Promise((resolve) => setTimeout(resolve, 100));
+
+          const saved = await this.document.save();
+
+          if (saved && !this.document.isDirty) {
+            log(
+              "Document auto-saved successfully after tool_execute block generation",
+            );
+          } else {
+            log(
+              "Document auto-save did not complete after tool_execute block generation",
+            );
+          }
+        } else {
+          log(
+            "Auto-save is disabled, skipping save after tool_execute block generation",
+          );
+        }
+      } catch (error) {
+        log(
+          `Error during auto-save after tool_execute block generation: ${error}`,
+        );
+        // Don't show error to user as auto-save is a convenience feature
+      }
+    } else {
+      log(
+        `Failed to insert ${openingFenceMatch ? "closing fence and " : ""}tool_execute block`,
+      );
+      // Since adding the tool_execute block failed, hide the status
+      requestStatusBarUpdate(this.document.uri.fsPath, "streaming finished");
+    }
+  }
+
+  /**
    * Check if an error is a server error (5xx) or a rate limit error (429)
    * or any other error that would benefit from retrying
    */
@@ -377,6 +619,16 @@ export class StreamingService {
 
           let tokenCount = 0;
 
+          // Parallel tool call support: once a tool call completes, everything that
+          // follows is buffered and further complete tool calls are popped off the
+          // left of the buffer and emitted (but not executed) until the buffer stops
+          // looking like a tool call or the stream ends.
+          let bufferingMode = false;
+          let bufferText = "";
+          let toolExecuteInserted = false;
+          let updateFailed = false;
+          let cancelledExternally = false;
+
           // Create a batching wrapper for the stream
           const batchingStream = this.createBatchingWrapper(stream, 100); // 100ms batching interval
 
@@ -384,6 +636,7 @@ export class StreamingService {
             // Check streamer status at the beginning of each token processing
             if (!streamer.isActive) {
               log("Streamer no longer active, stopping stream immediately");
+              cancelledExternally = true;
               break;
             }
 
@@ -396,6 +649,22 @@ export class StreamingService {
                 appendToChatHistory(streamer.historyFilePath, tokens.join(""));
               }
 
+              if (bufferingMode) {
+                // A tool call has already completed in this turn: buffer what follows
+                // and keep popping further tool calls off the left of the buffer.
+                bufferText += tokens.join("");
+                const bufferResult = await this.processBufferedToolCalls(
+                  streamer,
+                  bufferText,
+                );
+                bufferText = bufferResult.remainingBuffer;
+                if (bufferResult.stop) {
+                  updateFailed = bufferResult.failed;
+                  break;
+                }
+                continue;
+              }
+
               // Check if adding these tokens would complete a tool call
               const currentTokens = [...streamer.tokens, ...tokens].join("");
               const toolCallResult =
@@ -404,7 +673,7 @@ export class StreamingService {
               // Check if we have a completed tool call
               if (toolCallResult && toolCallResult.isComplete) {
                 log(
-                  "Detected completed tool call, will truncate at position " +
+                  "Detected completed tool call, entering buffering mode at position " +
                     toolCallResult.endIndex,
                 );
                 
@@ -484,104 +753,25 @@ export class StreamingService {
                     }
                   }
 
-                  // Always add tool_execute block (auto-execution is always enabled)
-                  // Add tool_execute block after the last token
-                  const text = this.document.getText();
-                  const blockStart = this.findBlockStartPosition(
-                    text,
-                    streamer,
+                  // Parallel tool calls: don't stop here. Buffer everything that
+                  // follows this tool call and keep emitting further tool calls.
+                  // The tool_execute block is added once the sequence ends.
+                  bufferingMode = true;
+                  bufferText = currentTokens.substring(endIndex);
+                  log(
+                    `Entering buffering mode with ${bufferText.length} buffered chars`,
                   );
 
-                  if (blockStart !== -1) {
-
-                    if (blockStart !== -1) {
-                      const currentText = streamer.tokens.join("");
-                      const insertPosition = this.document.positionAt(
-                        blockStart + currentText.length,
-                      );
-
-                      // Check for unbalanced fence blocks
-                      // Look for opening ``` before <tool_call> but no matching closing ```
-                      // Allow for any annotation after the triple backticks
-                      const openingFenceMatch =
-                        /```(?:[a-zA-Z0-9_\-]*)?(?:\s*\n|\s+)\s*<tool_call>[\s\S]*?\n\s*<\/tool_call>(?!\s*\n\s*```)/s.exec(
-                          currentText,
-                        );
-
-                      let textToInsert = "";
-
-                      if (openingFenceMatch) {
-                        log(
-                          "Detected unbalanced fence block - adding closing fence before tool_execute block",
-                        );
-                        textToInsert = "\n```\n\n# %% tool_execute\n";
-                      } else {
-                        textToInsert = "\n\n# %% tool_execute\n";
-                      }
-
-                      const edit = new vscode.WorkspaceEdit();
-                      edit.insert(
-                        this.document.uri,
-                        insertPosition,
-                        textToInsert,
-                      );
-                      const applied = await vscode.workspace.applyEdit(edit);
-
-                      if (applied) {
-                        log(
-                          `Successfully inserted ${openingFenceMatch ? "closing fence and " : ""}tool_execute block`,
-                        );
-                        
-                        // The tool_execute block has been added, but we need to make sure the status
-                        // stays visible until the DocumentListener picks up the change and executes the tool
-                        log(`Ensuring tool execution status remains visible for manual execution`);
-                        requestStatusBarUpdate(this.document.uri.fsPath, "tool auto-execution started");
-
-                        // Mark streamer as inactive BEFORE auto-save to prevent conflicts
-                        streamer.isActive = false;
-                        log("Marked streamer as inactive after tool_execute block insertion");
-
-                        // Small delay to ensure state propagation before triggering auto-save document changes
-                        await new Promise(resolve => setTimeout(resolve, 50));
-
-                        // Auto-save after tool_execute block generation if enabled
-                        try {
-                          if (getAutoSaveAfterStreaming()) {
-                            log("Auto-saving document after tool_execute block generation");
-                            
-                            // Brief delay to ensure tool_execute block addition is processed by VS Code
-                            await new Promise(resolve => setTimeout(resolve, 100));
-                            
-                            const saved = await this.document.save();
-                            
-                            if (saved && !this.document.isDirty) {
-                              log("Document auto-saved successfully after tool_execute block generation");
-                            } else if (saved && this.document.isDirty) {
-                              log("Document save returned true but document is still dirty after tool_execute block generation");
-                            } else {
-                              log("Document auto-save failed after tool_execute block generation - save() returned false");
-                            }
-                          } else {
-                            log("Auto-save is disabled, skipping save after tool_execute block generation");
-                          }
-                        } catch (error) {
-                          log(`Error during auto-save after tool_execute block generation: ${error}`);
-                          // Don't show error to user as auto-save is a convenience feature
-                        }
-                      } else {
-                        log(
-                          `Failed to insert ${openingFenceMatch ? "closing fence and " : ""}tool_execute block`,
-                        );
-                        // Since adding the tool_execute block failed, hide the status
-                        requestStatusBarUpdate(this.document.uri.fsPath, "streaming finished");
-                      }
-                    } else {
-                      log("Could not find position to insert tool_execute block");
-                    }
+                  const bufferResult = await this.processBufferedToolCalls(
+                    streamer,
+                    bufferText,
+                  );
+                  bufferText = bufferResult.remainingBuffer;
+                  if (bufferResult.stop) {
+                    updateFailed = bufferResult.failed;
+                    break;
                   }
-
-                  // Streamer already marked as inactive above before auto-save
-                  break;
+                  continue;
                 } catch (error) {
                   log(`Error handling tool call: ${error}`);
                   // Continue as normal if handling tool call fails
@@ -617,8 +807,27 @@ export class StreamingService {
           }
 
           log(
-            `Stream completed successfully, processed ${tokenCount} tokens total, provider: ${this.provider}`,
+            `Stream completed successfully, processed ${tokenCount} tokens total, provider: ${this.provider}${bufferingMode ? " (buffered tool calls)" : ""}`,
           );
+
+          // Parallel tool calls: a single tool_execute block is added after the whole
+          // sequence of tool calls has been written to the assistant block. The
+          // document listener then executes them one at a time, adding another
+          // tool_execute block after each result until all of them are done.
+          if (
+            bufferingMode &&
+            !toolExecuteInserted &&
+            !updateFailed &&
+            !cancelledExternally
+          ) {
+            if (bufferText.trim().length > 0) {
+              log(
+                `Discarding ${bufferText.length} buffered chars that were not part of a tool call`,
+              );
+            }
+            await this.insertToolExecuteBlockAfterToolCalls(streamer);
+            toolExecuteInserted = true;
+          }
           
           // Capture success state immediately to avoid race conditions
           streamCompletedSuccessfully = true;

--- a/src/tools/cdataTest.ts
+++ b/src/tools/cdataTest.ts
@@ -8,18 +8,18 @@ import {
 // Test function to verify CDATA parsing
 export function testCdataFunctionality() {
   // Test case 1: Basic CDATA extraction
-  const simpleParam = `<param name="content"><![CDATA[This is content]]></param>`;
+  const simpleParam = `<cmd:param name="content"><![CDATA[This is content]]></cmd:param>`;
   console.log(
     "Test 1 - Simple CDATA content:",
     extractCdataContent(simpleParam),
   );
 
   // Test case 2: CDATA with XML-like content
-  const xmlInCdata = `<param name="content"><![CDATA[This contains <tool_call> and </tool_call> tags]]></param>`;
+  const xmlInCdata = `<cmd:param name="content"><![CDATA[This contains <cmd:tool_call> and </cmd:tool_call> tags]]></cmd:param>`;
   console.log("Test 2 - CDATA with XML tags:", extractCdataContent(xmlInCdata));
 
   // Test case 3: Multiple CDATA sections
-  const multipleCdata = `<param name="content"><![CDATA[Section 1]]></param><![CDATA[Section 2]]></param>`;
+  const multipleCdata = `<cmd:param name="content"><![CDATA[Section 1]]></cmd:param><![CDATA[Section 2]]></cmd:param>`;
   console.log(
     "Test 3 - Multiple CDATA sections:",
     extractCdataContent(multipleCdata),
@@ -37,12 +37,12 @@ export function testCdataFunctionality() {
 
   // Test case 5: Complete tool call with CDATA
   const completeToolCall = `
-<tool_call>
-<tool_name>FileWriteOrEdit</tool_name>
-<param name="file_path">/test/path.txt</param>
-<param name="percentage_to_change">5</param>
-<param name="file_content_or_search_replace_blocks"><![CDATA[This content has XML-like tags such as </tool_call> that should be treated as text]]></param>
-</tool_call>
+<cmd:tool_call>
+<cmd:tool_name>FileWriteOrEdit</cmd:tool_name>
+<cmd:param name="file_path">/test/path.txt</cmd:param>
+<cmd:param name="percentage_to_change">5</cmd:param>
+<cmd:param name="file_content_or_search_replace_blocks"><![CDATA[This content has XML-like tags such as </cmd:tool_call> that should be treated as text]]></cmd:param>
+</cmd:tool_call>
   `;
 
   const parsedCall = parseToolCall(completeToolCall);
@@ -50,11 +50,11 @@ export function testCdataFunctionality() {
 
   // Test case 6: Check for completed tool call with CDATA
   const incompleteToolCall = `
-<tool_call>
-<tool_name>FileWriteOrEdit</tool_name>
-<param name="file_path">/test/path.txt</param>
-<param name="percentage_to_change">5</param>
-<param name="file_content_or_search_replace_blocks"><![CDATA[This content has XML-like tags
+<cmd:tool_call>
+<cmd:tool_name>FileWriteOrEdit</cmd:tool_name>
+<cmd:param name="file_path">/test/path.txt</cmd:param>
+<cmd:param name="percentage_to_change">5</cmd:param>
+<cmd:param name="file_content_or_search_replace_blocks"><![CDATA[This content has XML-like tags
   `;
 
   console.log(
@@ -68,16 +68,16 @@ export function testCdataFunctionality() {
 
   // Test case 7: Tool call with CDATA containing search/replace markers
   const searchReplaceToolCall = `
-<tool_call>
-<tool_name>FileWriteOrEdit</tool_name>
-<param name="file_path">/test/path.txt</param>
-<param name="percentage_to_change">5</param>
-<param name="file_content_or_search_replace_blocks"><![CDATA[<<<<<<< SEARCH
+<cmd:tool_call>
+<cmd:tool_name>FileWriteOrEdit</cmd:tool_name>
+<cmd:param name="file_path">/test/path.txt</cmd:param>
+<cmd:param name="percentage_to_change">5</cmd:param>
+<cmd:param name="file_content_or_search_replace_blocks"><![CDATA[<<<<<<< SEARCH
 <div>Original content</div>
 =======
 <div>New content with XML tags</div>
->>>>>>> REPLACE]]></param>
-</tool_call>
+>>>>>>> REPLACE]]></cmd:param>
+</cmd:tool_call>
   `;
 
   const parsedSearchReplace = parseToolCall(searchReplaceToolCall);

--- a/src/tools/toolCallParser.ts
+++ b/src/tools/toolCallParser.ts
@@ -31,40 +31,13 @@ export enum ToolCallFormatType {
  * @returns The extracted XML content with fencing removed
  */
 export function extractXmlContent(toolCallXml: string): string {
-  // First check if the input directly starts with <tool_call>
-  const directToolCallMatch = /^\s*<tool_call>/.test(toolCallXml);
-  if (directToolCallMatch) {
-    log(`Tool call format: ${ToolCallFormatType.NON_FENCED} (direct)`);
-    return toolCallXml;
+  const content = toolCallXml.trim();
+  if (content.startsWith("<cmd:tool_call>")) {
+    log(`Tool call format: ${ToolCallFormatType.NON_FENCED}`);
+    return content;
   }
-
-  // Check if the tool call has a proper opening and closing fence
-  // Support any language annotation such as xml, tool_call, tool_code, etc.
-  const properFenceMatch =
-    /```(?:[a-zA-Z0-9_\-]*)?(?:\s*\n|\s+)([\s\S]*?)\n\s*```/s.exec(toolCallXml);
-
-  // If not, check if it has just an opening fence (partially fenced)
-  const partialFenceMatch = !properFenceMatch
-    ? /```(?:[a-zA-Z0-9_\-]*)?(?:\s*\n|\s+)([\s\S]*?)$/s.exec(toolCallXml)
-    : null;
-
-  // Extract the actual XML content based on the fence status
-  const xmlContent = properFenceMatch
-    ? properFenceMatch[1]
-    : partialFenceMatch
-      ? partialFenceMatch[1]
-      : toolCallXml;
-
-  // Log the detected format for debugging
-  const formatType = properFenceMatch
-    ? ToolCallFormatType.PROPERLY_FENCED
-    : partialFenceMatch
-      ? ToolCallFormatType.PARTIALLY_FENCED
-      : ToolCallFormatType.NON_FENCED;
-
-  log(`Tool call format: ${formatType}`);
-
-  return xmlContent;
+  log("Tool call must use the un-fenced cmd format");
+  return "";
 }
 
 /**
@@ -142,7 +115,7 @@ export function areCdataTagsBalanced(text: string): boolean {
 export function areParamsComplete(text: string): boolean {
   // Extract each param block and verify it's properly formed
   const paramBlocks: string[] = [];
-  const paramRegex = /<param\s+name=["'](.*?)["']>([\s\S]*?)<\/param>/gs;
+  const paramRegex = /<cmd:param\s+name=["'](.*?)["']>([\s\S]*?)<\/cmd:param>/gs;
   let paramMatch;
 
   while ((paramMatch = paramRegex.exec(text)) !== null) {
@@ -262,22 +235,22 @@ export function parseToolCall(toolCallXml: string): ParsedToolCall | null {
     // This helps with finding tag boundaries but preserves the original content for parameter extraction
     const preprocessedXml = preprocessXmlWithCdata(xmlContent);
 
-    // Focus on the part between <tool_call> and \n</tool_call> tags using the preprocessed XML
+    // Focus on the part between <cmd:tool_call> and \n</cmd:tool_call> tags using the preprocessed XML
     // Require the closing tag to be on its own line
     const toolCallContentMatch =
-      /<tool_call>\s*([\s\S]*?)\n\s*<\/tool_call>/s.exec(preprocessedXml);
+      /<cmd:tool_call>\s*([\s\S]*?)\n\s*<\/cmd:tool_call>/s.exec(preprocessedXml);
 
     // Get the corresponding part from the original XML for parameter extraction
     // This ensures we have the original CDATA tags intact when parsing parameters
     let originalToolCallContent = "";
     if (toolCallContentMatch) {
       // Use the same pattern with newline requirement for the original content
-      const fullMatch = /<tool_call>[\s\S]*?\n\s*<\/tool_call>/s.exec(
+      const fullMatch = /<cmd:tool_call>[\s\S]*?\n\s*<\/cmd:tool_call>/s.exec(
         xmlContent,
       );
       if (fullMatch) {
         originalToolCallContent = fullMatch[0].replace(
-          /<tool_call>\s*|\n\s*<\/tool_call>/g,
+          /<cmd:tool_call>\s*|\n\s*<\/cmd:tool_call>/g,
           "",
         );
       }
@@ -285,7 +258,7 @@ export function parseToolCall(toolCallXml: string): ParsedToolCall | null {
       // Fallback to the original string if preprocessed matching fails
       // Still require newline before closing tag
       originalToolCallContent =
-        /<tool_call>\s*([\s\S]*?)\n\s*<\/tool_call>/s.exec(xmlContent)?.[1] ||
+        /<cmd:tool_call>\s*([\s\S]*?)\n\s*<\/cmd:tool_call>/s.exec(xmlContent)?.[1] ||
         "";
     }
 
@@ -296,7 +269,7 @@ export function parseToolCall(toolCallXml: string): ParsedToolCall | null {
 
     // Simple XML parser for tool calls - allow indentation with more flexible whitespace
     // Use the original content for name extraction
-    const nameMatch = /<tool_name>\s*(.*?)\s*<\/tool_name>/s.exec(
+    const nameMatch = /<cmd:tool_name>\s*(.*?)\s*<\/cmd:tool_name>/s.exec(
       originalToolCallContent,
     );
     if (!nameMatch) {
@@ -311,7 +284,7 @@ export function parseToolCall(toolCallXml: string): ParsedToolCall | null {
     // Updated regex to require quotes around parameter names and be flexible with whitespace
     // Use the original content with intact CDATA sections
     const paramRegex =
-      /<param\s+name=["'](.*?)["']>\s*([\s\S]*?)\s*<\/param>/gs;
+      /<cmd:param\s+name=["'](.*?)["']>\s*([\s\S]*?)\s*<\/cmd:param>/gs;
     let paramMatch;
 
     while ((paramMatch = paramRegex.exec(originalToolCallContent)) !== null) {
@@ -354,59 +327,10 @@ export function parseToolCall(toolCallXml: string): ParsedToolCall | null {
 export function findToolCallPatterns(
   text: string,
 ): Array<{ type: ToolCallFormatType; match: RegExpExecArray }> {
-  const patterns = [];
-
-  // First try to match the simplest and most direct case - tool_call tags with newline before closing tag
-  // This is the most permissive pattern and will work in direct messages
-  const directToolCallRegex = /<tool_call>[\s\S]*?\n\s*<\/tool_call>/s;
-  const directMatch = directToolCallRegex.exec(text);
-
-  // First try to match properly fenced tool calls (with opening and closing fences)
-  // Allow for any annotation after the triple backticks (xml, tool_call, tool_code, etc.)
-  // Require the closing tool_call tag to be on its own line
-  const properlyFencedToolCallRegex =
-    /```(?:[a-zA-Z0-9_\-]*)?(?:\s*\n|\s+)(?:\s*)<tool_call>[\s\S]*?\n\s*<\/tool_call>(?:\s*)\n\s*```/s;
-  const properlyFencedMatch = properlyFencedToolCallRegex.exec(text);
-
-  // Then try to match partially fenced tool calls (with opening fence but missing closing fence)
-  // Allow for any annotation after the triple backticks
-  // Require the closing tool_call tag to be on its own line
-  const partiallyFencedToolCallRegex =
-    /```(?:[a-zA-Z0-9_\-]*)?(?:\s*\n|\s+)(?:\s*)<tool_call>[\s\S]*?\n\s*<\/tool_call>(?!\s*\n\s*```)/s;
-  const partiallyFencedMatch = partiallyFencedToolCallRegex.exec(text);
-
-  // Then try to match non-fenced tool calls with newlines around them
-  // Specifically requires newlines around the closing tag
-  const nonFencedToolCallRegex = /\n\s*<tool_call>[\s\S]*?\n\s*<\/tool_call>/s;
-  const nonFencedMatch = nonFencedToolCallRegex.exec(text);
-
-  // Collect all matches with their types
-  if (directMatch) {
-    patterns.push({ type: ToolCallFormatType.NON_FENCED, match: directMatch });
-  }
-
-  if (properlyFencedMatch) {
-    patterns.push({
-      type: ToolCallFormatType.PROPERLY_FENCED,
-      match: properlyFencedMatch,
-    });
-  }
-
-  if (partiallyFencedMatch) {
-    patterns.push({
-      type: ToolCallFormatType.PARTIALLY_FENCED,
-      match: partiallyFencedMatch,
-    });
-  }
-
-  if (nonFencedMatch) {
-    patterns.push({
-      type: ToolCallFormatType.NON_FENCED,
-      match: nonFencedMatch,
-    });
-  }
-
-  return patterns;
+  const open = "<cmd:tool_call>";
+  const end = "</cmd:tool_call>";
+  const match = new RegExp(open + "[\\s\\S]*?\\n\\s*" + end, "s").exec(text);
+  return match ? [{ type: ToolCallFormatType.NON_FENCED, match }] : [];
 }
 
 /**
@@ -461,7 +385,7 @@ export function checkForCompletedToolCall(text: string): ToolCallCheckResult | {
   }
 
   // Extract the tool name from the completed tool call
-  const toolNameMatch = /<tool_name>\s*(.*?)\s*<\/tool_name>/s.exec(originalTextPortion);
+  const toolNameMatch = /<cmd:tool_name>\s*(.*?)\s*<\/cmd:tool_name>/s.exec(originalTextPortion);
   const toolName = toolNameMatch ? toolNameMatch[1].trim() : '';
 
   // Log the finding

--- a/src/tools/toolCallParser.ts
+++ b/src/tools/toolCallParser.ts
@@ -16,14 +16,27 @@ export type ToolCallCheckResult =
   | { isComplete: true; endIndex: number };
 
 /**
- * Types of code fencing in tool calls
+ * Types of tool call formatting. Only the un-fenced cmd format is supported.
  */
 export enum ToolCallFormatType {
-  PROPERLY_FENCED = "properly-fenced",
-  PARTIALLY_FENCED = "partially-fenced",
   NON_FENCED = "non-fenced",
   UNKNOWN = "unknown",
 }
+
+/** Qualified tags of the only supported tool call format */
+export const CMD_TOOL_CALL_OPEN_TAG = "\u003ccmd:tool_call\u003e";
+export const CMD_TOOL_CALL_CLOSE_TAG = "\u003c/cmd:tool_call\u003e";
+
+/**
+ * The single source of truth for what a complete tool call looks like: the opening
+ * tag, any body, and a closing tag that starts its own line. The newline keeps a
+ * closing tag mentioned inline inside a parameter value from ending the call early.
+ *
+ * Used by findToolCallPatterns (streaming detection), findAllToolCalls (listener)
+ * and parseToolCall, which must all agree.
+ */
+export const TOOL_CALL_PATTERN =
+  CMD_TOOL_CALL_OPEN_TAG + "[\\s\\S]*?\\n\\s*" + CMD_TOOL_CALL_CLOSE_TAG;
 
 /**
  * Extracts XML content from a fenced or non-fenced tool call
@@ -327,10 +340,22 @@ export function parseToolCall(toolCallXml: string): ParsedToolCall | null {
 export function findToolCallPatterns(
   text: string,
 ): Array<{ type: ToolCallFormatType; match: RegExpExecArray }> {
-  const open = "<cmd:tool_call>";
-  const end = "</cmd:tool_call>";
-  const match = new RegExp(open + "[\\s\\S]*?\\n\\s*" + end, "s").exec(text);
+  const match = new RegExp(TOOL_CALL_PATTERN, "s").exec(text);
   return match ? [{ type: ToolCallFormatType.NON_FENCED, match }] : [];
+}
+
+/**
+ * Finds every complete tool call in a finished assistant block, in order.
+ *
+ * This shares TOOL_CALL_PATTERN with the streaming detector and parseToolCall, so
+ * a call that is collected here is always a call the parser accepts. Divergence
+ * here would break the positional matching of tool calls to tool_execute blocks.
+ */
+export function findAllToolCalls(text: string): string[] {
+  return Array.from(
+    text.matchAll(new RegExp(TOOL_CALL_PATTERN, "gs")),
+    (match) => match[0],
+  );
 }
 
 /**

--- a/src/tools/toolExecutor.ts
+++ b/src/tools/toolExecutor.ts
@@ -1,7 +1,5 @@
 import { log, requestStatusBarUpdate, onActiveFileChanged } from "../extension";
 import * as vscode from "vscode";
-import * as path from "path";
-import * as fs from "fs";
 import { mcpClientManager } from "../mcpClientManager";
 import { statusManager } from "../extension";
 import { McpToolExecutionResult } from "../types";
@@ -13,49 +11,6 @@ const activeToolExecutions = new Map<string, AbortController>();
 let currentToolExecution: string | null = null;
 // Track cancelled executions to ignore any late responses
 const cancelledExecutions = new Set<string>();
-
-/**
- * Saves the parsed tool call to a log file for debugging
- * @param toolName The name of the tool being called
- * @param params The parameters of the tool call
- * @param rawToolCall The raw XML of the tool call
- */
-function saveToolCallLog(
-  toolName: string,
-  params: Record<string, string>,
-  rawToolCall: string,
-): void {
-  try {
-    // Create samples/cmdassets directory if it doesn't exist
-    const rootDir = path.resolve(__dirname, "..", "..");
-    const assetsDir = path.join(rootDir, "samples", "cmdassets");
-
-    if (!fs.existsSync(assetsDir)) {
-      fs.mkdirSync(assetsDir, { recursive: true });
-    }
-
-    // Create a timestamp-based filename
-    const date = new Date();
-    const timestamp = `${date.getFullYear()}${String(date.getMonth() + 1).padStart(2, "0")}${String(date.getDate()).padStart(2, "0")}-${String(date.getHours()).padStart(2, "0")}${String(date.getMinutes()).padStart(2, "0")}${String(date.getSeconds()).padStart(2, "0")}`;
-    const randomSuffix = Math.random().toString(36).substring(2, 8);
-    const filename = `tool-call-${timestamp}-${randomSuffix}.txt`;
-    const filePath = path.join(assetsDir, filename);
-
-    // Format the log content
-    let content = `# Tool Call Log\n\n`;
-    content += `Timestamp: ${date.toISOString()}\n`;
-    content += `Tool Name: ${toolName}\n\n`;
-    content += `## Parsed Parameters\n\`\`\`json\n${JSON.stringify(params, null, 2)}\n\`\`\`\n\n`;
-    content += `## Raw Tool Call XML\n\`\`\`xml\n${rawToolCall}\n\`\`\`\n`;
-
-    // Write to file
-    fs.writeFileSync(filePath, content, "utf8");
-    log(`Tool call log saved to: ${filePath}`);
-  } catch (error) {
-    log(`Error saving tool call log: ${error}`);
-    // Don't throw - we want this to be non-blocking
-  }
-}
 
 export async function executeToolCall(
   toolName: string,
@@ -109,11 +64,6 @@ export async function executeToolCall(
     }
     
     log(`ReadImage with file_path=${params.file_path} and document context from ${document.fileName}`);
-  }
-
-  // Save the parsed tool call to a log file if we have the raw XML
-  if (rawToolCall) {
-    saveToolCallLog(toolName, params, rawToolCall);
   }
 
   // Execute through MCP

--- a/src/tools/toolExecutor.ts
+++ b/src/tools/toolExecutor.ts
@@ -5,6 +5,7 @@ import * as fs from "fs";
 import { mcpClientManager } from "../mcpClientManager";
 import { statusManager } from "../extension";
 import { McpToolExecutionResult } from "../types";
+import { parseToolCall as parseCanonicalToolCall } from "./toolCallParser";
 
 // Track active tool executions for cancellation
 const activeToolExecutions = new Map<string, AbortController>();
@@ -199,98 +200,6 @@ export function formatToolResult(result: string): string {
 export function parseToolCall(
   toolCallXml: string,
 ): { name: string; params: Record<string, string>; rawXml: string } | null {
-  try {
-    // First, check if the tool call has a proper opening and closing fence
-    const properFenceMatch =
-      /```(?:xml|tool_call)?\s*\n([\s\S]*?)\n\s*```/s.exec(toolCallXml);
-
-    // If not, check if it has just an opening fence (partially fenced)
-    const partialFenceMatch = !properFenceMatch
-      ? /```(?:xml|tool_call)?\s*\n([\s\S]*?)$/s.exec(toolCallXml)
-      : null;
-
-    // Extract the actual XML content based on the fence status
-    const xmlContent = properFenceMatch
-      ? properFenceMatch[1]
-      : partialFenceMatch
-        ? partialFenceMatch[1]
-        : toolCallXml;
-
-    log(
-      `Tool call format: ${properFenceMatch ? "properly fenced" : partialFenceMatch ? "partially fenced" : "not fenced"}`,
-    );
-
-    // Focus on the part between <tool_call> and </tool_call> tags
-    // Require the closing tag to be on its own line
-    const toolCallContentMatch =
-      /<tool_call>\s*([\s\S]*?)\n\s*<\/tool_call>/s.exec(xmlContent);
-
-    // If we can't find the tool_call tags, try on the original string as a fallback
-    // Still require the closing tag to be on its own line
-    const toolCallContent = toolCallContentMatch
-      ? toolCallContentMatch[1]
-      : /<tool_call>\s*([\s\S]*?)\n\s*<\/tool_call>/s.exec(toolCallXml)?.[1] ||
-        "";
-
-    if (!toolCallContent) {
-      log("Could not extract tool call content");
-      return null;
-    }
-
-    // Simple XML parser for tool calls - allow indentation with more flexible whitespace
-    const nameMatch = /<tool_name>\s*(.*?)\s*<\/tool_name>/s.exec(
-      toolCallContent,
-    );
-    if (!nameMatch) {
-      log("Could not find tool_name tag");
-      return null;
-    }
-
-    const toolName = nameMatch[1].trim();
-    const params: Record<string, string> = {};
-
-    // Extract parameters with more precise formatting
-    // Updated regex to require quotes around parameter names and be flexible with whitespace
-    const paramRegex =
-      /<param\s+name=["'](.*?)["']>\s*([\s\S]*?)\s*<\/param>/gs;
-    let paramMatch;
-
-    while ((paramMatch = paramRegex.exec(toolCallContent)) !== null) {
-      const paramName = paramMatch[1].trim(); // No need to replace quotes, they're already handled in the regex
-      const paramValue = paramMatch[2].trim();
-
-      // Store all parameter values as strings, even JSON objects or arrays
-      params[paramName] = paramValue;
-
-      // Log the parameter type for debugging
-      if (
-        paramValue.trim().startsWith("{") ||
-        paramValue.trim().startsWith("[")
-      ) {
-        log(
-          `Parameter "${paramName}" appears to be JSON, storing as string: ${paramValue.substring(0, 50)}${paramValue.length > 50 ? "..." : ""}`,
-        );
-      }
-    }
-
-    // Log the full details including parameter values for debugging
-    log(
-      `Parsed tool call ${toolName} with ${Object.keys(params).length} parameters`,
-    );
-    Object.entries(params).forEach(([key, value]) => {
-      log(
-        `  Parameter "${key}" = "${value.substring(0, 50)}${value.length > 50 ? "..." : ""}"`,
-      );
-    });
-
-    // Return the parsed tool call with the raw XML included
-    return {
-      name: toolName,
-      params,
-      rawXml: xmlContent,
-    };
-  } catch (error) {
-    log(`Error parsing tool call: ${error}`);
-    return null;
-  }
+  const parsed = parseCanonicalToolCall(toolCallXml);
+  return parsed ? { ...parsed, rawXml: toolCallXml } : null;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@
 /**
  * Represents the type of content in a message
  */
-export type ContentType = "text" | "image";
+export type ContentType = "text" | "image" | "thinking";
 
 /**
  * Text content in a message
@@ -24,9 +24,73 @@ export interface ImageContent {
 }
 
 /**
+ * Kinds of provider reasoning payload that can be replayed to an API.
+ * "raw" means there is no opaque payload, only human readable thinking text.
+ */
+export type ThinkingPayloadKind =
+  | "anthropic_signature"
+  | "anthropic_redacted"
+  | "openai_encrypted"
+  | "reasoning_details"
+  | "raw";
+
+/**
+ * Provider specific reasoning payload, stored in cmdassets/thinking_map.json and
+ * referenced from the document by an 8 character hash.
+ */
+export interface ThinkingPayload {
+  kind: ThinkingPayloadKind;
+  /** Anthropic: opaque signature for a thinking block */
+  signature?: string;
+  /** Anthropic: exact thinking text the signature was produced for */
+  text?: string;
+  /** Anthropic: opaque data of a redacted_thinking block */
+  data?: string;
+  /** OpenAI Responses: reasoning item id (rs_...) */
+  itemId?: string;
+  /** OpenAI Responses: encrypted reasoning content */
+  encryptedContent?: string;
+  /** OpenAI chat completions (OpenRouter et al): reasoning_details array */
+  reasoningDetails?: any[];
+  /** OpenAI chat completions: which field the reasoning text came in */
+  field?: "reasoning" | "reasoning_content" | "reasoning_summary";
+}
+
+/**
+ * A thinking payload as stored in the map, qualified by the model that produced it
+ */
+export interface ThinkingMapEntry extends ThinkingPayload {
+  model: string;
+  createdAt: string;
+}
+
+/**
+ * On disk shape of cmdassets/thinking_map.json
+ */
+export interface ThinkingMapFile {
+  version: 1;
+  entries: Record<string, ThinkingMapEntry>;
+}
+
+/**
+ * Thinking (reasoning) content of an assistant message
+ */
+export interface ThinkingContent {
+  type: "thinking";
+  /** Human readable thinking text (summary or raw), without the signature line */
+  value: string;
+  /** Qualified model name from the signature line, if present */
+  model?: string;
+  /** 8 character hash referencing an entry in thinking_map.json */
+  hash?: string;
+  /** Payload resolved from thinking_map.json, if the entry could be read */
+  payload?: ThinkingPayload;
+}
+
+/**
  * Union type for different types of content
  */
-export type Content = TextContent | ImageContent;
+export type Content = TextContent | ImageContent | ThinkingContent;
 
 /**
  * Discriminated union for raw/rich MCP content types returned by tools or prompts
@@ -168,6 +232,29 @@ export interface StreamerState {
    * Used to determine whether to automatically add a user block after completion
    */
   isHandlingToolCall?: boolean;
+
+  /**
+   * Whether a "## %% thinking" section is currently open in the document
+   */
+  thinkingOpen?: boolean;
+
+  /**
+   * Whether a "## %% text" section is currently open in the document
+   */
+  textOpen?: boolean;
+
+  /**
+   * Whether any thinking section was written during this turn. Once true, all
+   * normal assistant content has to live under a "## %% text" marker.
+   */
+  sawThinking?: boolean;
+
+  /**
+   * Offset within the joined tokens where the current text section starts.
+   * Tool call detection only scans from here, so thinking text and signature
+   * lines can never be mistaken for a tool call.
+   */
+  scanOffset?: number;
 
   /**
    * Function to cancel the stream. This can be called externally

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,8 +42,6 @@ export interface ThinkingPayload {
   kind: ThinkingPayloadKind;
   /** Anthropic: opaque signature for a thinking block */
   signature?: string;
-  /** Anthropic: exact thinking text the signature was produced for */
-  text?: string;
   /** Anthropic: opaque data of a redacted_thinking block */
   data?: string;
   /** OpenAI Responses: reasoning item id (rs_...) */

--- a/src/types.ts
+++ b/src/types.ts
@@ -214,6 +214,22 @@ export interface MessageParam {
 /**
  * State of a streaming response
  */
+export interface ChatHistoryUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  [key: string]: unknown;
+}
+
+export interface ChatHistoryFile {
+  system: string;
+  history: MessageParam[];
+  usage: ChatHistoryUsage | null;
+  cost: number | null;
+  metadata: Record<string, unknown>;
+}
+
 export interface StreamerState {
   messageIndex: number;
   tokens: string[];

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -1,35 +1,24 @@
 import * as path from "path";
 import * as fs from "fs";
 import * as vscode from "vscode";
-import { MessageParam } from "../types";
+import { ChatHistoryFile, ChatHistoryUsage, MessageParam } from "../types";
 
 /**
- * Resolves file paths that may be relative to the current document
+ * Resolves file paths that may be relative to the current document.
  */
 export function resolveFilePath(
   filePath: string,
   document: vscode.TextDocument,
 ): string {
-  // If path starts with ~ replace with home dir
   if (filePath.startsWith("~")) {
     return filePath.replace(/^~/, process.env.HOME || "");
   }
-
-  // If it's an absolute path, return as is
   if (path.isAbsolute(filePath)) {
     return filePath;
   }
-
-  // Try to resolve relative to the document
-  const documentDir = path.dirname(document.uri.fsPath);
-  const resolvedPath = path.resolve(documentDir, filePath);
-
-  return resolvedPath;
+  return path.resolve(path.dirname(document.uri.fsPath), filePath);
 }
 
-/**
- * Check if a file exists and is accessible
- */
 export function fileExists(filePath: string): boolean {
   try {
     fs.accessSync(filePath, fs.constants.R_OK);
@@ -39,10 +28,6 @@ export function fileExists(filePath: string): boolean {
   }
 }
 
-/**
- * Read file as a buffer, handling errors gracefully
- * Returns undefined if file can't be read
- */
 export function readFileAsBuffer(filePath: string): Buffer | undefined {
   try {
     return fs.readFileSync(filePath);
@@ -52,10 +37,6 @@ export function readFileAsBuffer(filePath: string): Buffer | undefined {
   }
 }
 
-/**
- * Read text file content as string
- * Returns undefined if file can't be read
- */
 export function readFileAsText(filePath: string): string | undefined {
   try {
     return fs.readFileSync(filePath, "utf8");
@@ -65,146 +46,141 @@ export function readFileAsText(filePath: string): string | undefined {
   }
 }
 
-/**
- * Check if a file is an image based on extension
- */
 export function isImageFile(filePath: string): boolean {
-  const ext = path.extname(filePath).toLowerCase();
-  return [".png", ".jpg", ".jpeg", ".gif", ".webp"].includes(ext);
+  return [".png", ".jpg", ".jpeg", ".gif", ".webp"].includes(
+    path.extname(filePath).toLowerCase(),
+  );
 }
 
-/**
- * Ensure a directory exists, creating it if necessary
- */
 export function ensureDirectoryExists(dirPath: string): void {
   if (!fs.existsSync(dirPath)) {
-    try {
-      fs.mkdirSync(dirPath, { recursive: true });
-    } catch (error) {
-      console.error(`Error creating directory ${dirPath}:`, error);
-      throw error; // Re-throw the error to indicate failure
-    }
+    fs.mkdirSync(dirPath, { recursive: true });
   } else if (!fs.statSync(dirPath).isDirectory()) {
     throw new Error(`Path exists but is not a directory: ${dirPath}`);
   }
 }
 
-/**
- * Write text content to a file
- * Throws error on failure
- */
 export function writeFile(filePath: string, content: string): void {
-  try {
-    fs.writeFileSync(filePath, content, "utf8");
-  } catch (error) {
-    console.error(`Error writing file ${filePath}:`, error);
-    throw error; // Re-throw the error
-  }
+  fs.writeFileSync(filePath, content, "utf8");
 }
 
 /**
- * Save chat history to a file for debugging purposes
- * @param document The document containing the chat
- * @param messages The messages to be sent to the LLM
- * @param action The action being performed (e.g., "before_llm_call")
- * @param additionalContent Optional additional content to append to the file
- * @param systemPrompt Optional system prompt to include at the top
+ * Returns the configured asset directory. Relative paths are resolved against
+ * the chat document directory; absolute paths are used as-is.
  */
+export function getAssetsDirectory(docDir: string): string {
+  const configured = vscode.workspace
+    .getConfiguration("chatmd")
+    .get<string>("assetsPath", "cmdassets");
+  if (configured.startsWith("~")) {
+    return path.resolve(configured.replace(/^~/, process.env.HOME || ""));
+  }
+  return path.isAbsolute(configured)
+    ? configured
+    : path.resolve(docDir, configured);
+}
+
+export function getAssetsRelativePath(docDir: string, fileName: string): string {
+  return path
+    .relative(docDir, path.join(getAssetsDirectory(docDir), fileName))
+    .replace(/\\/g, "/");
+}
+
+function getChatMdCacheDirectory(): string {
+  const cacheRoot =
+    process.env.XDG_CACHE_HOME ||
+    path.join(process.env.HOME || process.cwd(), ".cache");
+  return path.join(cacheRoot, "chat.md");
+}
+
+function createHistoryFileName(document: vscode.TextDocument): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const baseName = path
+    .basename(document.fileName)
+    .replace(/[^a-zA-Z0-9._-]/g, "_");
+  return `${baseName}-${timestamp}-${Math.random().toString(36).slice(2, 8)}.json`;
+}
+
 export function saveChatHistory(
   document: vscode.TextDocument,
   messages: readonly MessageParam[],
-  action: string,
-  systemPrompt?: string, // Added systemPrompt parameter
-  additionalContent?: string,
+  _action: string,
+  systemPrompt = "",
+  metadata: Record<string, unknown> = {},
 ): string {
   try {
-    // Create .cmd_history directory relative to the chat document
-    const docDir = path.dirname(document.uri.fsPath);
-    const historyDir = path.join(docDir, ".cmd_history");
+    const historyDir = getChatMdCacheDirectory();
     ensureDirectoryExists(historyDir);
-
-    // Create a timestamp-based filename
-    const timestamp = new Date()
-      .toISOString()
-      .replace(/:/g, "-")
-      .replace(/\..+Z/, "");
-    const filename = `history_${timestamp}_${action}.md`;
-    const filePath = path.join(historyDir, filename);
-
-    // Format messages into a readable markdown format
-    let content = `# Chat History Debug Log\n\n`;
-    content += `- **Timestamp:** ${new Date().toISOString()}\n`;
-    content += `- **Action:** ${action}\n`;
-    content += `- **Document:** ${document.fileName}\n\n`;
-
-    // Add System Prompt if provided
-    if (systemPrompt) {
-      content += `## System Prompt\n\n\`\`\`\n${systemPrompt}\n\`\`\`\n\n`;
-    }
-
-    content += `## Messages\n\n`;
-    messages.forEach((msg, index) => {
-      content += `### ${index + 1}. ${msg.role.toUpperCase()}\n\n`;
-
-      msg.content.forEach((item) => {
-        if (item.type === "text") {
-          content += `\`\`\`\n${item.value}\n\`\`\`\n\n`;
-        } else if (item.type === "image") {
-          content += `[Image: ${item.path}]\n\n`;
-        }
-      });
-    });
-
-    // Add additional content if provided
-    if (additionalContent) {
-      content += `## Additional Content\n\n\`\`\`\n${additionalContent}\n\`\`\`\n`;
-    }
-
-    // Write to file
-    writeFile(filePath, content);
-
+    const filePath = path.join(historyDir, createHistoryFileName(document));
+    const history: ChatHistoryFile = {
+      system: systemPrompt,
+      history: [...messages],
+      usage: null,
+      cost: null,
+      metadata: {
+        document: document.uri.fsPath,
+        createdAt: new Date().toISOString(),
+        ...metadata,
+      },
+    };
+    writeFile(filePath, JSON.stringify(history, null, 2) + "\n");
     return filePath;
   } catch (error) {
     console.error("Error saving chat history:", error);
-    // Don't throw - we want this to be non-blocking
     return "";
   }
 }
 
-/**
- * Append content to an existing chat history file
- * @param historyFilePath Path to the history file
- * @param content Content to append
- */
 export function appendToChatHistory(
   historyFilePath: string,
   content: string,
 ): void {
-  try {
-    if (!historyFilePath || !fileExists(historyFilePath)) {
-      return;
+  updateChatHistory(historyFilePath, (history) => {
+    const lastMessage = history.history[history.history.length - 1];
+    if (lastMessage?.role === "assistant") {
+      const text = lastMessage.content.find((item) => item.type === "text");
+      if (text && text.type === "text") {
+        text.value += content;
+      } else {
+        lastMessage.content.push({ type: "text", value: content });
+      }
+    } else {
+      history.history.push({
+        role: "assistant",
+        content: [{ type: "text", value: content }],
+      });
     }
+  });
+}
 
-    // Read existing content
-    const existingContent = readFileAsText(historyFilePath) || "";
-
-    // Append new content (raw tokens)
-    const updatedContent = existingContent + content;
-
-    // Write back to file
-    writeFile(historyFilePath, updatedContent);
+export function updateChatHistory(
+  historyFilePath: string,
+  update: (history: ChatHistoryFile) => void,
+): void {
+  try {
+    if (!historyFilePath || !fileExists(historyFilePath)) return;
+    const parsed = JSON.parse(readFileAsText(historyFilePath) || "") as ChatHistoryFile;
+    update(parsed);
+    writeFile(historyFilePath, JSON.stringify(parsed, null, 2) + "\n");
   } catch (error) {
-    console.error("Error appending to chat history:", error);
-    // Don't throw - we want this to be non-blocking
+    console.error("Error updating chat history:", error);
   }
 }
 
-/**
- * Get the log file path for a specific MCP server
- * @param logBasePath The base path for MCP logs
- * @param serverId The ID of the MCP server
- * @returns The full path to the log file for the server
- */
-export function getMcpServerLogPath(logBasePath: string, serverId: string): string {
+export function updateChatHistoryUsage(
+  historyFilePath: string,
+  usage: ChatHistoryUsage | undefined,
+): void {
+  if (!usage) return;
+  updateChatHistory(historyFilePath, (history) => {
+    history.usage = usage;
+    history.metadata.completedAt = new Date().toISOString();
+  });
+}
+
+export function getMcpServerLogPath(
+  logBasePath: string,
+  serverId: string,
+): string {
   return path.join(logBasePath, `${serverId}.log`);
 }

--- a/src/utils/mcpResultFormatter.ts
+++ b/src/utils/mcpResultFormatter.ts
@@ -8,7 +8,12 @@ import {
   McpToolExecutionResult,
 } from "../types";
 import { log } from "../extension";
-import { ensureDirectoryExists, writeFile } from "./fileUtils";
+import {
+  ensureDirectoryExists,
+  getAssetsDirectory,
+  getAssetsRelativePath,
+  writeFile,
+} from "./fileUtils";
 
 /**
  * Formats a rich MCP tool execution result into markdown text,
@@ -101,7 +106,7 @@ async function formatRenderableContent(
   assetLabel: string,
   sourceServerId: string | undefined,
 ): Promise<string[]> {
-  const assetsDir = path.join(docDir, "cmdassets");
+  const assetsDir = getAssetsDirectory(docDir);
   ensureDirectoryExists(assetsDir);
 
   const parts: string[] = [];
@@ -117,13 +122,13 @@ async function formatRenderableContent(
 
     if (item.type === "image") {
       imageCount += 1;
-      parts.push(saveBinaryAsset(item.data, item.mimeType, assetsDir, `${assetLabel}-image`, `![${assetLabel} image ${imageCount}]`));
+      parts.push(saveBinaryAsset(item.data, item.mimeType, docDir, assetsDir, `${assetLabel}-image`, `![${assetLabel} image ${imageCount}]`));
       continue;
     }
 
     if (item.type === "audio") {
       audioCount += 1;
-      parts.push(saveBinaryAsset(item.data, item.mimeType, assetsDir, `${assetLabel}-audio`, `[${assetLabel} audio ${audioCount}]`));
+      parts.push(saveBinaryAsset(item.data, item.mimeType, docDir, assetsDir, `${assetLabel}-audio`, `[${assetLabel} audio ${audioCount}]`));
       continue;
     }
 
@@ -140,7 +145,7 @@ async function formatRenderableContent(
 
     resourceCount += 1;
     const resourceLabel = `${assetLabel}-resource-${resourceCount}`;
-    parts.push(renderEmbeddedResource(item.resource, assetsDir, resourceLabel));
+    parts.push(renderEmbeddedResource(item.resource, docDir, assetsDir, resourceLabel));
   }
 
   return parts.filter((part) => part.trim().length > 0);
@@ -148,6 +153,7 @@ async function formatRenderableContent(
 
 function renderEmbeddedResource(
   resource: { uri: string; mimeType?: string; text?: string; blob?: string },
+  docDir: string,
   assetsDir: string,
   resourceLabel: string,
 ): string {
@@ -162,7 +168,7 @@ function renderEmbeddedResource(
     const filePath = path.join(assetsDir, fileName);
     writeFile(filePath, resource.text);
     log(`Saved embedded text resource to: ${filePath}`);
-    return `[Embedded Resource: ${resource.uri}](cmdassets/${fileName})`;
+    return `[Embedded Resource: ${resource.uri}](${getAssetsRelativePath(docDir, fileName)})`;
   }
 
   if (resource.blob !== undefined) {
@@ -173,7 +179,7 @@ function renderEmbeddedResource(
     const buffer = Buffer.from(resource.blob, "base64");
     fs.writeFileSync(filePath, buffer);
     log(`Saved embedded binary resource to: ${filePath}`);
-    return `[Embedded Binary Resource: ${resource.uri}](cmdassets/${fileName})`;
+    return `[Embedded Binary Resource: ${resource.uri}](${getAssetsRelativePath(docDir, fileName)})`;
   }
 
   return `[Embedded Resource: ${resource.uri}]`;
@@ -182,6 +188,7 @@ function renderEmbeddedResource(
 function saveBinaryAsset(
   data: string,
   mimeType: string,
+  docDir: string,
   assetsDir: string,
   assetLabel: string,
   markdownPrefix: string,
@@ -192,7 +199,7 @@ function saveBinaryAsset(
   const buffer = Buffer.from(data, "base64");
   fs.writeFileSync(filePath, buffer);
   log(`Saved MCP asset to: ${filePath}`);
-  return `${markdownPrefix}(cmdassets/${fileName})`;
+  return `${markdownPrefix}(${getAssetsRelativePath(docDir, fileName)})`;
 }
 
 function createAssetFileName(assetLabel: string, extension: string): string {

--- a/src/utils/messageCleanup.ts
+++ b/src/utils/messageCleanup.ts
@@ -1,6 +1,6 @@
 /**
  * Message cleanup performed immediately before an API call, modelled on
- * llm-codegen's anthropic_utils.clean_messages.
+ * provider-specific message cleanup before requests are sent.
  *
  * Invariants:
  *  - the number of messages never changes (a message emptied by cleanup gets a

--- a/src/utils/messageCleanup.ts
+++ b/src/utils/messageCleanup.ts
@@ -1,0 +1,164 @@
+/**
+ * Message cleanup performed immediately before an API call, modelled on
+ * llm-codegen's anthropic_utils.clean_messages.
+ *
+ * Invariants:
+ *  - the number of messages never changes (a message emptied by cleanup gets a
+ *    "[continuing]" text block instead of being dropped)
+ *  - at most one thinking block survives per assistant message, and it is moved to
+ *    the front of the content
+ *  - thinking produced by a different model, or a payload that the target API
+ *    cannot replay, is dropped (the payload only; the text may survive as raw)
+ *
+ * Kept free of vscode/extension imports so it can be tested standalone.
+ */
+
+import { Content, MessageParam, ThinkingContent } from "../types";
+
+export type ApiStyle = "anthropic" | "openai_chat" | "openai_responses";
+
+export interface CleanupOptions {
+  /** Model name the request is about to be sent to */
+  modelName: string;
+  /** Whether thinking is actually enabled for this request */
+  thinkingEnabled: boolean;
+  apiStyle: ApiStyle;
+}
+
+const CONTINUING_PLACEHOLDER = "[continuing]";
+
+function isThinking(block: Content): block is ThinkingContent {
+  return block.type === "thinking";
+}
+
+/**
+ * A payload can only be replayed to the API family that produced it. On a mismatch
+ * (for instance the same model switched from the Responses API to chat completions)
+ * the payload is dropped and the block degrades to raw thinking text.
+ */
+export function payloadUsableForApi(
+  block: ThinkingContent,
+  apiStyle: ApiStyle,
+): boolean {
+  const kind = block.payload?.kind;
+  if (!kind || kind === "raw") {
+    return false;
+  }
+  switch (apiStyle) {
+    case "anthropic":
+      return kind === "anthropic_signature" || kind === "anthropic_redacted";
+    case "openai_responses":
+      return kind === "openai_encrypted";
+    case "openai_chat":
+      return kind === "reasoning_details";
+  }
+}
+
+/**
+ * Thinking from another model must not be replayed. A block with no model
+ * attribution (hand written, or written before this feature) is kept as raw text.
+ */
+export function thinkingMatchesModel(
+  block: ThinkingContent,
+  modelName: string,
+): boolean {
+  if (!block.model) {
+    return true;
+  }
+  return block.model === modelName;
+}
+
+/** Trailing whitespace in the final assistant text block breaks the Anthropic API */
+function stripTrailingWhitespace(blocks: Content[]): Content[] {
+  const result = [...blocks];
+  for (let i = result.length - 1; i >= 0; i--) {
+    const block = result[i];
+    if (block.type !== "text") {
+      break;
+    }
+    const trimmed = block.value.replace(/\s+$/, "");
+    if (trimmed === "") {
+      result.splice(i, 1);
+      continue;
+    }
+    result[i] = { type: "text", value: trimmed };
+    break;
+  }
+  return result;
+}
+
+/**
+ * Select the single thinking block to send: the first one carrying a replayable
+ * payload, else the first one at all. Ordering follows the document, so an
+ * out-of-order signature that landed in a later section still wins over an earlier
+ * summary-only section.
+ */
+export function selectThinkingBlock(
+  blocks: ThinkingContent[],
+  apiStyle: ApiStyle,
+): ThinkingContent | undefined {
+  const withPayload = blocks.find((block) => payloadUsableForApi(block, apiStyle));
+  if (withPayload) {
+    return withPayload;
+  }
+  return blocks[0];
+}
+
+export function cleanMessagesForApi(
+  messages: readonly MessageParam[],
+  options: CleanupOptions,
+): MessageParam[] {
+  return messages.map((message) => {
+    let blocks: Content[] = message.content.filter((block) => {
+      if (block.type === "text") {
+        return block.value.trim() !== "";
+      }
+      return true;
+    });
+
+    const thinkingBlocks = blocks.filter(isThinking);
+
+    if (thinkingBlocks.length > 0) {
+      // Thinking only belongs to assistant turns
+      if (message.role !== "assistant" || !options.thinkingEnabled) {
+        blocks = blocks.filter((block) => !isThinking(block));
+      } else {
+        const candidates = thinkingBlocks.filter((block) =>
+          thinkingMatchesModel(block, options.modelName),
+        );
+        const chosen = selectThinkingBlock(candidates, options.apiStyle);
+        const others = blocks.filter((block) => !isThinking(block));
+
+        const usable = chosen
+          ? payloadUsableForApi(chosen, options.apiStyle)
+          : false;
+
+        if (!chosen || (!usable && options.apiStyle === "anthropic")) {
+          // Anthropic rejects thinking blocks it did not sign, so unsigned
+          // thinking is display only.
+          blocks = others;
+        } else {
+          const normalised: ThinkingContent = usable
+            ? chosen
+            : { type: "thinking", value: chosen.value, model: chosen.model };
+          // Thinking always goes first: Anthropic requires it and it keeps the
+          // replayed turn identical in shape to how it was produced.
+          blocks =
+            !usable && normalised.value.trim() === ""
+              ? others
+              : [normalised, ...others];
+        }
+      }
+    }
+
+    if (message.role === "assistant") {
+      blocks = stripTrailingWhitespace(blocks);
+    }
+
+    if (blocks.length === 0) {
+      blocks = [{ type: "text", value: CONTINUING_PLACEHOLDER }];
+    }
+
+    return { role: message.role, content: blocks };
+  });
+}

--- a/src/utils/messageCleanup.ts
+++ b/src/utils/messageCleanup.ts
@@ -87,23 +87,6 @@ function stripTrailingWhitespace(blocks: Content[]): Content[] {
   return result;
 }
 
-/**
- * Select the single thinking block to send: the first one carrying a replayable
- * payload, else the first one at all. Ordering follows the document, so an
- * out-of-order signature that landed in a later section still wins over an earlier
- * summary-only section.
- */
-export function selectThinkingBlock(
-  blocks: ThinkingContent[],
-  apiStyle: ApiStyle,
-): ThinkingContent | undefined {
-  const withPayload = blocks.find((block) => payloadUsableForApi(block, apiStyle));
-  if (withPayload) {
-    return withPayload;
-  }
-  return blocks[0];
-}
-
 export function cleanMessagesForApi(
   messages: readonly MessageParam[],
   options: CleanupOptions,
@@ -126,27 +109,37 @@ export function cleanMessagesForApi(
         const candidates = thinkingBlocks.filter((block) =>
           thinkingMatchesModel(block, options.modelName),
         );
-        const chosen = selectThinkingBlock(candidates, options.apiStyle);
+
+        // Find the first thinking block with non-empty opaque/encrypted content
+        const withOpaque = candidates.find(
+          (block) => block.payload && payloadUsableForApi(block, options.apiStyle),
+        );
+
         const others = blocks.filter((block) => !isThinking(block));
 
-        const usable = chosen
-          ? payloadUsableForApi(chosen, options.apiStyle)
-          : false;
-
-        if (!chosen || (!usable && options.apiStyle === "anthropic")) {
-          // Anthropic rejects thinking blocks it did not sign, so unsigned
-          // thinking is display only.
-          blocks = others;
+        if (withOpaque) {
+          // Opaque content exists — text is irrelevant, set it to empty string
+          const normalised: ThinkingContent = {
+            type: "thinking",
+            value: "",
+            model: withOpaque.model,
+            hash: withOpaque.hash,
+            payload: withOpaque.payload,
+          };
+          blocks = [normalised, ...others];
         } else {
-          const normalised: ThinkingContent = usable
-            ? chosen
-            : { type: "thinking", value: chosen.value, model: chosen.model };
-          // Thinking always goes first: Anthropic requires it and it keeps the
-          // replayed turn identical in shape to how it was produced.
-          blocks =
-            !usable && normalised.value.trim() === ""
-              ? others
-              : [normalised, ...others];
+          // No opaque content — use the first thinking block as raw text
+          const first = candidates[0];
+          if (first && first.value.trim() !== "") {
+            const normalised: ThinkingContent = {
+              type: "thinking",
+              value: first.value,
+              model: first.model,
+            };
+            blocks = [normalised, ...others];
+          } else {
+            blocks = others;
+          }
         }
       }
     }

--- a/src/utils/modelCapabilities.ts
+++ b/src/utils/modelCapabilities.ts
@@ -1,0 +1,127 @@
+/**
+ * Model capability checks needed for reasoning support. Kept free of imports so it
+ * can be tested outside VS Code.
+ */
+
+export type ReasoningEffort = "none" | "minimal" | "low" | "medium" | "high";
+
+/** Anthropic effort levels accepted by adaptive thinking */
+export type AdaptiveEffort = "low" | "medium" | "high";
+
+interface ClaudeVersion {
+  family: string;
+  major: number;
+  minor: number;
+}
+
+function parseClaudeVersion(model: string): ClaudeVersion | undefined {
+  const match = /claude-(opus|sonnet|haiku|fable|mythos)-(\d+)(?:[-.](\d+))?/i.exec(
+    model,
+  );
+  if (!match) {
+    return undefined;
+  }
+  return {
+    family: match[1].toLowerCase(),
+    major: parseInt(match[2], 10),
+    minor: match[3] ? parseInt(match[3], 10) : 0,
+  };
+}
+
+/**
+ * Models that take thinking: {type: "adaptive"} plus output_config.effort instead of
+ * the older thinking: {type: "enabled", budget_tokens}. Claude 4.6 and everything
+ * from 5 onwards.
+ */
+export function isAdaptiveThinkingModel(model: string): boolean {
+  const version = parseClaudeVersion(model);
+  if (!version) {
+    return false;
+  }
+  if (version.family === "fable" || version.family === "mythos") {
+    return true;
+  }
+  if (version.major >= 5) {
+    return true;
+  }
+  return version.major === 4 && version.minor >= 6;
+}
+
+/**
+ * Models that omit thinking content from responses unless display: "summarized" is
+ * requested (Claude 4.7+, 5.x, Fable/Mythos).
+ */
+export function omitsThinkingByDefault(model: string): boolean {
+  const version = parseClaudeVersion(model);
+  if (!version) {
+    return false;
+  }
+  if (version.family === "fable" || version.family === "mythos") {
+    return true;
+  }
+  if (version.major >= 5) {
+    return true;
+  }
+  return version.major === 4 && version.minor >= 7;
+}
+
+/**
+ * Models where adaptive thinking is always on: sending a disabled thinking config
+ * is rejected, so the param has to be omitted entirely.
+ */
+export function requiresAlwaysOnThinking(model: string): boolean {
+  const version = parseClaudeVersion(model);
+  return version?.family === "fable" && version.major === 5;
+}
+
+/**
+ * Older Anthropic models that still need the interleaved thinking beta header to
+ * think between tool calls. It is generally available from 4.6 onwards.
+ */
+export function needsInterleavedThinkingBeta(model: string): boolean {
+  const version = parseClaudeVersion(model);
+  if (!version) {
+    return false;
+  }
+  if (version.major > 4) {
+    return false;
+  }
+  return version.major === 4 && version.minor <= 5;
+}
+
+/** Map the configured reasoning effort onto Anthropic's adaptive effort levels */
+export function toAdaptiveEffort(effort: ReasoningEffort): AdaptiveEffort {
+  switch (effort) {
+    case "minimal":
+    case "low":
+    case "none":
+      return "low";
+    case "medium":
+      return "medium";
+    default:
+      return "high";
+  }
+}
+
+/**
+ * OpenAI models served by the Responses API rather than chat completions:
+ * the gpt-* family and the o-series reasoning models.
+ */
+export function isResponsesApiModel(model: string): boolean {
+  return /^(gpt-|o[1-9])/i.test(model.trim());
+}
+
+/**
+ * True when a base URL points at OpenAI itself. Any other host (OpenRouter, local
+ * servers, Azure gateways, ...) only speaks chat completions.
+ */
+export function isOpenAiBaseUrl(baseUrl?: string): boolean {
+  if (!baseUrl || !baseUrl.trim()) {
+    return true; // no override means api.openai.com
+  }
+  try {
+    return new URL(baseUrl).hostname.endsWith("api.openai.com");
+  } catch {
+    return false;
+  }
+}

--- a/src/utils/thinkingBlocks.ts
+++ b/src/utils/thinkingBlocks.ts
@@ -1,0 +1,250 @@
+/**
+ * Pure helpers for the "## %% thinking" / "## %% text" sub-blocks of an assistant
+ * turn, and for the streaming token protocol used to carry reasoning from the API
+ * clients to the streamer.
+ *
+ * This module intentionally has no imports so it can be unit tested outside VS Code.
+ */
+
+/** Marker that opens a thinking section inside an assistant block */
+export const THINKING_SECTION_MARKER = "## %% thinking";
+
+/** Marker that opens a normal text section inside an assistant block */
+export const TEXT_SECTION_MARKER = "## %% text";
+
+/**
+ * Prefixes used by the API clients to tag non-text stream tokens. They start with
+ * NUL so they can never collide with model output.
+ */
+export const THINKING_TOKEN_PREFIX = "\u0000thinking:";
+export const THINKING_PAYLOAD_PREFIX = "\u0000thinking_payload:";
+
+export interface AssistantSection {
+  type: "thinking" | "text";
+  content: string;
+}
+
+export interface ParsedThinkingSection {
+  /** Thinking text without the trailing signature line */
+  text: string;
+  /** Qualified model name from the signature line */
+  model?: string;
+  /** 8 character hash from the signature line */
+  hash?: string;
+}
+
+const SECTION_SPLIT_REGEX = /^## %% (thinking|text)[ \t]*$/im;
+const SECTION_TEST_REGEX = /^## %% (thinking|text)[ \t]*$/im;
+
+/** Greedy model part so the split happens on the last "::" of the line */
+const SIGNATURE_LINE_REGEX = /^(.+)::([0-9a-f]{8})$/;
+
+/**
+ * True when the assistant block uses the sectioned format. Blocks without any
+ * marker are plain text, which is the pre-existing format and stays supported.
+ */
+export function hasAssistantSections(text: string): boolean {
+  return SECTION_TEST_REGEX.test(text);
+}
+
+/**
+ * Split an assistant block into its thinking/text sections. A block with no
+ * markers yields a single text section with the whole content. Content appearing
+ * before the first marker is also treated as text.
+ */
+export function splitAssistantSections(text: string): AssistantSection[] {
+  if (!hasAssistantSections(text)) {
+    return [{ type: "text", content: text }];
+  }
+
+  const parts = text.split(SECTION_SPLIT_REGEX);
+  const sections: AssistantSection[] = [];
+
+  if (parts.length > 0 && parts[0].trim() !== "") {
+    sections.push({ type: "text", content: parts[0] });
+  }
+
+  for (let i = 1; i < parts.length; i += 2) {
+    const kind = parts[i].toLowerCase() === "thinking" ? "thinking" : "text";
+    sections.push({ type: kind, content: parts[i + 1] ?? "" });
+  }
+
+  return sections;
+}
+
+/**
+ * Parse a thinking section: the last non-empty line is the signature line when it
+ * matches "qualified_model_name::hash8", and is not part of the thinking text.
+ */
+export function parseThinkingSection(content: string): ParsedThinkingSection {
+  const lines = content.split(/\r?\n/);
+
+  let lastNonEmpty = -1;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (lines[i].trim() !== "") {
+      lastNonEmpty = i;
+      break;
+    }
+  }
+
+  if (lastNonEmpty === -1) {
+    return { text: "" };
+  }
+
+  const match = SIGNATURE_LINE_REGEX.exec(lines[lastNonEmpty].trim());
+  if (!match) {
+    return { text: content.trim() };
+  }
+
+  const model = match[1].trim();
+  if (!model) {
+    return { text: content.trim() };
+  }
+
+  return {
+    text: lines.slice(0, lastNonEmpty).join("\n").trim(),
+    model,
+    hash: match[2],
+  };
+}
+
+/** Renders the trailing line of a thinking section */
+export function formatSignatureLine(model: string, hash: string): string {
+  return `${model}::${hash}`;
+}
+
+/**
+ * Returns only the text sections of an assistant block, so tool call scanning
+ * never looks inside thinking text.
+ */
+export function stripThinkingSections(text: string): string {
+  if (!hasAssistantSections(text)) {
+    return text;
+  }
+  return splitAssistantSections(text)
+    .filter((section) => section.type === "text")
+    .map((section) => section.content)
+    .join("\n");
+}
+
+/** True when the token carries thinking text rather than assistant text */
+export function isThinkingToken(token: string): boolean {
+  return token.startsWith(THINKING_TOKEN_PREFIX);
+}
+
+/** True when the token carries a reasoning payload */
+export function isThinkingPayloadToken(token: string): boolean {
+  return token.startsWith(THINKING_PAYLOAD_PREFIX);
+}
+
+export function encodeThinkingToken(text: string): string {
+  return THINKING_TOKEN_PREFIX + text;
+}
+
+export function decodeThinkingToken(token: string): string {
+  return token.substring(THINKING_TOKEN_PREFIX.length);
+}
+
+export function encodeThinkingPayloadToken(payload: unknown): string {
+  return THINKING_PAYLOAD_PREFIX + JSON.stringify(payload);
+}
+
+export function decodeThinkingPayloadToken(token: string): any | undefined {
+  try {
+    return JSON.parse(token.substring(THINKING_PAYLOAD_PREFIX.length));
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Which section of the assistant block the streamer is currently writing into.
+ */
+export interface SectionState {
+  thinkingOpen: boolean;
+  textOpen: boolean;
+  sawThinking: boolean;
+  /** Offset in the assistant block where the current text section content starts */
+  scanOffset: number;
+}
+
+/**
+ * Renders a batch of stream tokens into the text to append to the assistant block,
+ * inserting section markers as the token kind changes and updating `state`.
+ *
+ * Writing is strictly append-only: a signature arriving after text has started
+ * opens another thinking section instead of editing the earlier one.
+ *
+ * @param recordPayload stores the payload and returns its "model::hash" line, or
+ *        undefined when the payload could not be stored
+ */
+export function renderStreamTokens(
+  tokens: string[],
+  alreadyWritten: string,
+  state: SectionState,
+  recordPayload: (token: string) => string | undefined,
+): string {
+  let out = "";
+
+  const needsNewline = (): boolean => {
+    const soFar = alreadyWritten + out;
+    return soFar.length > 0 && !soFar.endsWith("\n");
+  };
+
+  const openThinkingSection = (): void => {
+    if (needsNewline()) {
+      out += "\n";
+    }
+    out += THINKING_SECTION_MARKER + "\n";
+    state.sawThinking = true;
+    state.textOpen = false;
+  };
+
+  for (const token of tokens) {
+    if (isThinkingPayloadToken(token)) {
+      const signatureLine = recordPayload(token);
+      if (!signatureLine) {
+        continue;
+      }
+      if (!state.thinkingOpen) {
+        openThinkingSection();
+      } else if (needsNewline()) {
+        out += "\n";
+      }
+      out += signatureLine + "\n";
+      // The signature always ends its thinking section
+      state.thinkingOpen = false;
+      continue;
+    }
+
+    if (isThinkingToken(token)) {
+      const thinkingText = decodeThinkingToken(token);
+      if (!thinkingText) {
+        continue;
+      }
+      if (!state.thinkingOpen) {
+        openThinkingSection();
+        state.thinkingOpen = true;
+      }
+      out += thinkingText;
+      continue;
+    }
+
+    // Normal assistant text: once thinking has appeared, text must live under a
+    // "## %% text" marker
+    if (state.sawThinking && !state.textOpen) {
+      if (needsNewline()) {
+        out += "\n";
+      }
+      out += TEXT_SECTION_MARKER + "\n";
+      state.textOpen = true;
+      state.thinkingOpen = false;
+      // Tool call scanning starts after the marker, so thinking text and signature
+      // lines can never be mistaken for a tool call
+      state.scanOffset = alreadyWritten.length + out.length;
+    }
+    out += token;
+  }
+
+  return out;
+}

--- a/src/utils/thinkingMap.ts
+++ b/src/utils/thinkingMap.ts
@@ -1,0 +1,114 @@
+/**
+ * Storage for provider reasoning payloads.
+ *
+ * The document only carries "qualified_model_name::hash8" at the end of a thinking
+ * section; the payload itself (Anthropic signature, OpenAI encrypted content,
+ * OpenRouter reasoning_details, ...) lives in cmdassets/thinking_map.json next to
+ * the tool result assets, shared by every .chat.md file in that directory.
+ *
+ * Entries are never garbage collected, and a missing entry degrades gracefully:
+ * the thinking section is then treated as display only raw text.
+ */
+
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as path from "path";
+import { ThinkingMapEntry, ThinkingMapFile, ThinkingPayload } from "../types";
+
+const ASSETS_DIR = "cmdassets";
+const MAP_FILE_NAME = "thinking_map.json";
+
+/** Absolute path of the map for a document directory */
+export function getThinkingMapPath(docDir: string): string {
+  return path.join(docDir, ASSETS_DIR, MAP_FILE_NAME);
+}
+
+/** Deterministic JSON so the same payload always hashes to the same value */
+function stableStringify(value: any): string {
+  if (value === null || value === undefined) {
+    return "null";
+  }
+  if (typeof value !== "object") {
+    return JSON.stringify(value) ?? "null";
+  }
+  if (Array.isArray(value)) {
+    return "[" + value.map(stableStringify).join(",") + "]";
+  }
+  const keys = Object.keys(value).sort();
+  return (
+    "{" +
+    keys
+      .map((key) => JSON.stringify(key) + ":" + stableStringify(value[key]))
+      .join(",") +
+    "}"
+  );
+}
+
+/** 8 character hash of a payload, used as the document facing id */
+export function computeThinkingHash(entry: ThinkingMapEntry): string {
+  const { createdAt: _createdAt, ...hashable } = entry;
+  return crypto
+    .createHash("sha256")
+    .update(stableStringify(hashable))
+    .digest("hex")
+    .substring(0, 8);
+}
+
+export function readThinkingMap(docDir: string): ThinkingMapFile {
+  const mapPath = getThinkingMapPath(docDir);
+  try {
+    if (!fs.existsSync(mapPath)) {
+      return { version: 1, entries: {} };
+    }
+    const parsed = JSON.parse(fs.readFileSync(mapPath, "utf8"));
+    if (parsed && typeof parsed === "object" && parsed.entries) {
+      return { version: 1, entries: parsed.entries };
+    }
+  } catch {
+    // Corrupt or unreadable map: behave as if empty rather than breaking the chat
+  }
+  return { version: 1, entries: {} };
+}
+
+function writeThinkingMap(docDir: string, map: ThinkingMapFile): boolean {
+  const mapPath = getThinkingMapPath(docDir);
+  try {
+    fs.mkdirSync(path.dirname(mapPath), { recursive: true });
+    fs.writeFileSync(mapPath, JSON.stringify(map, null, 2), "utf8");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Store a payload and return its hash. Storing the same payload twice is a no-op
+ * because the hash is derived from the payload itself.
+ */
+export function putThinkingEntry(
+  docDir: string,
+  model: string,
+  payload: ThinkingPayload,
+): string {
+  const entry: ThinkingMapEntry = {
+    ...payload,
+    model,
+    createdAt: new Date().toISOString(),
+  };
+  const hash = computeThinkingHash(entry);
+
+  const map = readThinkingMap(docDir);
+  if (!map.entries[hash]) {
+    map.entries[hash] = entry;
+    writeThinkingMap(docDir, map);
+  }
+  return hash;
+}
+
+/** Look up a payload by hash, or undefined when the entry is unknown */
+export function getThinkingEntry(
+  docDir: string,
+  hash: string,
+): ThinkingMapEntry | undefined {
+  return readThinkingMap(docDir).entries[hash];
+}

--- a/src/utils/thinkingMap.ts
+++ b/src/utils/thinkingMap.ts
@@ -14,13 +14,13 @@ import * as crypto from "crypto";
 import * as fs from "fs";
 import * as path from "path";
 import { ThinkingMapEntry, ThinkingMapFile, ThinkingPayload } from "../types";
+import { getAssetsDirectory } from "./fileUtils";
 
-const ASSETS_DIR = "cmdassets";
 const MAP_FILE_NAME = "thinking_map.json";
 
 /** Absolute path of the map for a document directory */
 export function getThinkingMapPath(docDir: string): string {
-  return path.join(docDir, ASSETS_DIR, MAP_FILE_NAME);
+  return path.join(getAssetsDirectory(docDir), MAP_FILE_NAME);
 }
 
 /** Deterministic JSON so the same payload always hashes to the same value */


### PR DESCRIPTION
## Summary

This PR consolidates the extensive chat.md improvements accumulated on the current main branch.

## Included changes

- Add Anthropic extended/adaptive thinking support, including replayable signatures and redacted thinking payloads.
- Add OpenAI Chat Completions and Responses API reasoning support, including encrypted reasoning replay and reasoning details.
- Support parallel tool calls within a single assistant response.
- Improve tool-call parsing, streaming idempotency, continuation, cancellation, and malformed tool-call handling.
- Add MCP Streamable HTTP support with SSE fallback, MCP prompts, resources, diagnostics, refresh, and resource opening.
- Add per-file API configuration overrides and provider/model/reasoning/token configuration handling.
- Move chat history to the global XDG-style cache at ~/.cache/chat.md/ with one JSON file per API turn.
- Store system prompt, message history, usage metadata, and a reserved null cost field in history files.
- Capture token usage from Anthropic, OpenAI Chat Completions, and OpenAI Responses streams.
- Remove tool execution log files.
- Make generated asset storage configurable through chatmd.assetsPath.
- Make the context-chat shortcut always create a new chat instead of cancelling an active stream.
- Keep streaming cancellation available through the status bar and cancel command.
- Automatically add .cmd_history/ and cmdassets/ to the Git repository containing the streamed chat file, without delaying the API request.

## Validation

- npm run compile passes.
- Existing repository lint/type-check environment still has missing eslint-plugin-prettier and an older TypeScript version incompatible with newer dependency declarations.