### PR TITLE
Document optional Parallel Search MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,21 @@ chat.md supports the new **Streamable HTTP** transport from the [MCP spec 2025-1
 }
 ```
 
+#### Parallel Search (optional)
+
+To opt in to web search and URL fetching, explicitly edit your own VS Code settings and add this separately named server to your existing `chatmd.mcpServers` map. Do not replace your other configured servers:
+
+```json
+"chatmd.mcpServers": {
+  "parallel-search": {
+    "url": "https://search.parallel.ai/mcp",
+    "transport": "streamable-http"
+  }
+}
+```
+
+The endpoint needs no account or API key, and native Streamable HTTP transport headers are optional. When you explicitly use its tools, user-provided search objectives, search queries, and requested URLs are sent to Parallel. See the [Parallel Search MCP documentation](https://docs.parallel.ai/integrations/mcp/search-mcp) for details.
+
 You can also pass custom HTTP headers (e.g. for authentication):
 
 ```json


### PR DESCRIPTION
## Why

Adds an optional web search and URL-fetching MCP server for chat.md users who choose to extend their VS Code chat workflow. The endpoint does not require an account or API key.

## Changes

- Add a separate `parallel-search` example to the existing Remote MCP Servers (Streamable HTTP) section.
- Require users to explicitly edit their own VS Code settings and merge the server into their existing `chatmd.mcpServers` map, preserving configured servers, providers, examples, security settings, and defaults.
- Note that native Streamable HTTP headers are optional.
- Disclose that, when the tools are explicitly used, user-provided search objectives, search queries, and requested URLs are sent to Parallel.

## Validation

- `git diff --check`: passed.
- README section content assertions for the endpoint, transport, opt-in guidance, authentication, optional headers, privacy disclosure, and canonical documentation link: passed.
- `git status --short`: confirmed `README.md` is the only changed path.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.